### PR TITLE
Require Run call to avoid handler setup race condition

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func DialWebTransport(ctx context.Context, addr string) (*Peer, error) {
 	wc := &webTransportConn{
 		sess: conn,
 	}
-	return newClientPeer(ctx, wc, false)
+	return newClientPeer(ctx, wc)
 }
 
 func DialQUIC(ctx context.Context, addr string) (*Peer, error) {
@@ -92,7 +92,7 @@ func DialQUIC(ctx context.Context, addr string) (*Peer, error) {
 	qc := &quicConn{
 		conn: conn,
 	}
-	p, err := newClientPeer(ctx, qc, true)
+	p, err := newClientPeer(ctx, qc)
 	if err != nil {
 		if errors.Is(err, errUnsupportedVersion) {
 			conn.CloseWithError(SessionTerminatedErrorCode, errUnsupportedVersion.Error())

--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -70,6 +70,7 @@ func NewClient(p *moqtransport.Peer) (*Client, error) {
 		c.rooms[id].st = st
 		return c.rooms[id].trackID, 0, nil
 	})
+	go c.peer.Run(context.Background(), false)
 	return c, nil
 }
 

--- a/examples/chat/server.go
+++ b/examples/chat/server.go
@@ -106,6 +106,7 @@ func (s *Server) peerHandler() moqtransport.PeerHandlerFunc {
 			s.nextTrackID += 1
 			return s.nextTrackID, time.Duration(0), nil
 		})
+		go p.Run(context.Background(), false)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -181,7 +181,6 @@ func (s *Server) ListenQUIC(ctx context.Context, addr string) error {
 }
 
 func (s *Server) Listen(ctx context.Context, l listener) error {
-	_, enableDatagrams := l.(*quicListener)
 	for {
 		conn, err := l.Accept(context.TODO())
 		if err != nil {
@@ -200,11 +199,6 @@ func (s *Server) Listen(ctx context.Context, l listener) error {
 			}
 			continue
 		}
-		// TODO: This should probably be a map keyed by the MoQ-URI the request
-		// is targeting
-		go func() {
-			peer.run(ctx, enableDatagrams)
-		}()
 		if s.Handler != nil {
 			s.Handler.Handle(peer)
 		}


### PR DESCRIPTION
Close #2 

This requires the user to explicitly call *Run* on the peer object when handling it. It is not ideal because it is required to set up handlers before calling *Run*, and only then can a user do any Subscribe/Announce calls.