### PR TITLE
added role argument to client setup functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/quic-go/webtransport-go"
 )
 
-func DialWebTransport(ctx context.Context, addr string) (*Peer, error) {
+func DialWebTransport(ctx context.Context, addr string, role uint64) (*Peer, error) {
 	d := webtransport.Dialer{
 		RoundTripper: &http3.RoundTripper{
 			DisableCompression: false,
@@ -28,10 +28,10 @@ func DialWebTransport(ctx context.Context, addr string) (*Peer, error) {
 	wc := &webTransportConn{
 		sess: conn,
 	}
-	return newClientPeer(ctx, wc)
+	return newClientPeer(ctx, wc, role)
 }
 
-func DialQUIC(ctx context.Context, addr string) (*Peer, error) {
+func DialQUIC(ctx context.Context, addr string, role uint64) (*Peer, error) {
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true,
 		NextProtos:         []string{"moq-00"},
@@ -45,7 +45,7 @@ func DialQUIC(ctx context.Context, addr string) (*Peer, error) {
 	qc := &quicConn{
 		conn: conn,
 	}
-	p, err := newClientPeer(ctx, qc)
+	p, err := newClientPeer(ctx, qc, role)
 	if err != nil {
 		if errors.Is(err, errUnsupportedVersion) {
 			conn.CloseWithError(SessionTerminatedErrorCode, errUnsupportedVersion.Error())

--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -29,7 +29,7 @@ type Client struct {
 }
 
 func NewQUICClient(ctx context.Context, addr string) (*Client, error) {
-	p, err := moqtransport.DialQUIC(ctx, addr)
+	p, err := moqtransport.DialQUIC(ctx, addr, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func NewQUICClient(ctx context.Context, addr string) (*Client, error) {
 }
 
 func NewWebTransportClient(ctx context.Context, addr string) (*Client, error) {
-	p, err := moqtransport.DialWebTransport(ctx, addr)
+	p, err := moqtransport.DialWebTransport(ctx, addr, 3)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/date-client/main.go
+++ b/examples/date-client/main.go
@@ -27,9 +27,9 @@ func run(addr string, wt bool) error {
 	var err error
 
 	if wt {
-		p, err = moqtransport.DialWebTransport(ctx, addr)
+		p, err = moqtransport.DialWebTransport(ctx, addr, 3)
 	} else {
-		p, err = moqtransport.DialQUIC(ctx, addr)
+		p, err = moqtransport.DialQUIC(ctx, addr, 3)
 	}
 	if err != nil {
 		return err

--- a/peer.go
+++ b/peer.go
@@ -118,7 +118,7 @@ func newServerPeer(ctx context.Context, conn connection) (*Peer, error) {
 	return p, nil
 }
 
-func newClientPeer(ctx context.Context, conn connection) (*Peer, error) {
+func newClientPeer(ctx context.Context, conn connection, clientRole uint64) (*Peer, error) {
 	s, err := conn.OpenStreamSync(ctx)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func newClientPeer(ctx context.Context, conn connection) (*Peer, error) {
 		SetupParameters: map[uint64]parameter{
 			roleParameterKey: varintParameter{
 				k: roleParameterKey,
-				v: ingestionDeliveryRole,
+				v: clientRole,
 			},
 		},
 	}


### PR DESCRIPTION
Client needs to specify their role parameter in the initial setup message with the server. This change adds the ability to specify the client role when requesting for a new connection with the server.