### PR TITLE
MoQ URI Handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,10 +28,10 @@ func DialWebTransport(ctx context.Context, addr string, role uint64) (*Peer, err
 	wc := &webTransportConn{
 		sess: conn,
 	}
-	return newClientPeer(ctx, wc, role)
+	return newClientPeer(ctx, wc, role, "")
 }
 
-func DialQUIC(ctx context.Context, addr string, role uint64) (*Peer, error) {
+func DialQUIC(ctx context.Context, addr string, role uint64, path string) (*Peer, error) {
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true,
 		NextProtos:         []string{"moq-00"},
@@ -45,7 +45,7 @@ func DialQUIC(ctx context.Context, addr string, role uint64) (*Peer, error) {
 	qc := &quicConn{
 		conn: conn,
 	}
-	p, err := newClientPeer(ctx, qc, role)
+	p, err := newClientPeer(ctx, qc, role, path)
 	if err != nil {
 		if errors.Is(err, errUnsupportedVersion) {
 			conn.CloseWithError(SessionTerminatedErrorCode, errUnsupportedVersion.Error())

--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -29,7 +29,7 @@ type Client struct {
 }
 
 func NewQUICClient(ctx context.Context, addr string) (*Client, error) {
-	p, err := moqtransport.DialQUIC(ctx, addr, 3)
+	p, err := moqtransport.DialQUIC(ctx, addr, 3, "")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/date-client/main.go
+++ b/examples/date-client/main.go
@@ -29,7 +29,7 @@ func run(addr string, wt bool) error {
 	if wt {
 		p, err = moqtransport.DialWebTransport(ctx, addr, 3)
 	} else {
-		p, err = moqtransport.DialQUIC(ctx, addr, 3)
+		p, err = moqtransport.DialQUIC(ctx, addr, 3, "")
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Setting up and saving of client setup parameters. Added a new field in Peer to save role and path parameters from client when Server listens from a new peer.