### PR TITLE
add raw quic support for chat server

### DIFF
--- a/examples/chat/server.go
+++ b/examples/chat/server.go
@@ -82,6 +82,7 @@ func (s *server) run() error {
 				EnableDatagrams:     true,
 				LocalRole:           moqtransport.RolePubSub,
 				AnnouncementHandler: s.sessions,
+				SubscriptionHandler: s.sessions,
 			}
 			if err := p.RunServer(ctx); err != nil {
 				p.Close()


### PR DESCRIPTION
when chat-client runs by "./chat -quic" and "join room_id client_name", chat-server will return SubscribeErrorMessage with "track not found".

With this patch, mixed chat client (raw quic or webtransport) can join the same chat-server and chat each other.