### PR TITLE
More documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,65 @@
-# Media over QUIC Transport
+# Media over QUIC Transport (MoQT)
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/mengelbart/moqtransport.svg)](https://pkg.go.dev/github.com/mengelbart/moqtransport)
 
-`moqtransport` is an implementation of [Media over QUIC
-Transport](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/) on top of
-[quic-go](https://github.com/quic-go/quic-go) and optionally
-[webtransport-go](https://github.com/quic-go/webtransport-go/).
+`moqtransport` is a Go implementation of [Media over QUIC Transport](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/) on top of [quic-go](https://github.com/quic-go/quic-go) and optionally [webtransport-go](https://github.com/quic-go/webtransport-go/).
+
+## Overview
+
+This library implements the Media over QUIC Transport (MoQT) protocol as defined in [draft-ietf-moq-transport-08](https://www.ietf.org/archive/id/draft-ietf-moq-transport-08.txt). MoQT is designed to operate over QUIC and WebTransport for efficient media delivery with a publish/subscribe model.
+
+### Implemented Features
+
+- **Core Protocol Support**: Implements MoQT over both QUIC and WebTransport
+- **Session Management**: Full support for session establishment, initialization, and termination
+- **Control Messages**: Implementation of all control message types defined in the specification
+- **Data Streams**: Support for object delivery via streams and datagrams
+- **Announcement System**: Track announcement and discovery mechanisms
+- **Subscription Handling**: Support for subscribing to tracks and handling subscription updates
+- **Error Handling**: Comprehensive error handling as defined in the specification
+
+### Implementation Status
+
+The implementation currently covers most aspects of the MoQT specification (draft-08), including:
+
+ Session establishment and initialization  
+ Control message encoding and handling  
+ Data stream management  
+ Track announcement and subscription  
+ Error handling  
+ Support for both QUIC and WebTransport  
+
+### Areas for Future Development
+
+- Enhanced relay support for CDN-like deployments
+- More comprehensive priority handling
+- Additional performance optimizations
+- Extended examples for various media streaming scenarios
 
 ## Usage
 
-See the [date examples in the examples directory](examples/date/README.md).
+See the [date examples in the examples directory](examples/date/README.md) for a simple demonstration of how to use this library.
 
+Basic usage involves:
+
+1. Creating a connection using either QUIC or WebTransport
+2. Establishing a MoQT session
+3. Implementing handlers for various MoQT messages
+4. Publishing or subscribing to tracks
+
+## Project Structure
+
+- `quicmoq/`: QUIC-specific implementation
+- `webtransportmoq/`: WebTransport-specific implementation
+- `internal/`: Internal implementation details
+- `examples/`: Example applications demonstrating usage
+- `integrationtests/`: Integration tests
+
+## Requirements
+
+- Go 1.23.6 or later
+- Dependencies are managed via Go modules
+
+## License
+
+See the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,11 @@
 
 ## Overview
 
-This library implements the Media over QUIC Transport (MoQT) protocol as defined in [draft-ietf-moq-transport-08](https://www.ietf.org/archive/id/draft-ietf-moq-transport-08.txt). MoQT is designed to operate over QUIC and WebTransport for efficient media delivery with a publish/subscribe model.
-
-### Implemented Features
-
-- **Core Protocol Support**: Implements MoQT over both QUIC and WebTransport
-- **Session Management**: Full support for session establishment, initialization, and termination
-- **Control Messages**: Implementation of all control message types defined in the specification
-- **Data Streams**: Support for object delivery via streams and datagrams
-- **Announcement System**: Track announcement and discovery mechanisms
-- **Subscription Handling**: Support for subscribing to tracks and handling subscription updates
-- **Error Handling**: Comprehensive error handling as defined in the specification
+This library implements the Media over QUIC Transport (MoQT) protocol as defined in [draft-ietf-moq-transport-08](https://www.ietf.org/archive/id/draft-ietf-moq-transport-08.txt). MoQT is designed to operate over QUIC or WebTransport for efficient media delivery with a publish/subscribe model.
 
 ### Implementation Status
 
+This code, as well as the specification, is work in progress.
 The implementation currently covers most aspects of the MoQT specification (draft-08), including:
 
  Session establishment and initialization  


### PR DESCRIPTION
One files have  updated:

1. The `top-level README.md` file

The other two files in the initial commit 
2. A new file `examples/date/moq_communication.md` file
3. The `examples/date/README.md` file

have been merged into a examples/date/README.md file in #197 (without the mkcert part).

The text in files 1 and 2 were to a big extent generated by the Claude 3.7 engine inside Windsurf.ai.
I still think it provides a quite accurate descriptions.