### PR TITLE
manage publishers with a map in the date example

### DIFF
--- a/examples/date/main.go
+++ b/examples/date/main.go
@@ -105,7 +105,7 @@ func runServer(opts *options) error {
 		trackname:  opts.trackname,
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
-		publishers: make(chan moqtransport.Publisher),
+		publishers: make(map[moqtransport.Publisher]struct{}),
 	}
 	return h.runServer(context.TODO())
 }
@@ -120,7 +120,7 @@ func runClient(opts *options) error {
 		trackname:  opts.trackname,
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
-		publishers: make(chan moqtransport.Publisher),
+		publishers: make(map[moqtransport.Publisher]struct{}),
 	}
 	return h.runClient(context.TODO(), opts.webtransport)
 }


### PR DESCRIPTION
Typically remove the publisher after the subscriber have quited. Currently UNSUBSCRIBE is missing in the common message types definition and we can also remove a publisher once the server recieves a UNSUBSCRIBE message in the example.