### PR TITLE
Add guidelines for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Pull Requests
+
+Contributions are welcome. Please consider adding an issue to discuss the
+proposed change before putting in a lot of work.
+
+## Commit Messages 
+
+Commit messages should follow [these guidelines](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines):
+
+* The subject line must be capitalized
+* The subject line must be written in the imperative
+* The subject line must not end in a period
+* The subject line should not exceed about 50 characters
+* A body can optionally be added to explain the change in more detail
+* The body must be separeted from the subject line with a blank line
+* The body should be wrapped at 72 characters
+
+Example:
+
+```
+Add guidelines for contributing
+
+Add a contributing.md file to document guidelines for contributing to
+moqtransport. The documentation contains guidelines for pull requests
+and commit messages and should be extended in the future.
+```
+


### PR DESCRIPTION
Add a contributing.md file to document guidelines for contributing to moqtransport. The documentation contains guidelines for pull requests and commit messages and should be extended in the future.