### PR TITLE
Expose Session, SubscribeID, and TrackAlias

### DIFF
--- a/announcement_response_writer.go
+++ b/announcement_response_writer.go
@@ -6,6 +6,11 @@ type announcementResponseWriter struct {
 	handled   bool
 }
 
+// Session returns the session associated with this response writer
+func (a *announcementResponseWriter) Session() *Session {
+	return a.session
+}
+
 func (a *announcementResponseWriter) Accept() error {
 	a.handled = true
 	return a.session.acceptAnnouncement(a.namespace)

--- a/announcement_subscription_response_writer.go
+++ b/announcement_subscription_response_writer.go
@@ -6,6 +6,11 @@ type announcementSubscriptionResponseWriter struct {
 	handled bool
 }
 
+// Session returns the session associated with this response writer
+func (a *announcementSubscriptionResponseWriter) Session() *Session {
+	return a.session
+}
+
 func (a *announcementSubscriptionResponseWriter) Accept() error {
 	a.handled = true
 	return a.session.acceptAnnouncementSubscription(a.prefix)

--- a/examples/date/main.go
+++ b/examples/date/main.go
@@ -106,6 +106,7 @@ func runServer(opts *options) error {
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
 		publishers: make(map[moqtransport.Publisher]struct{}),
+		sessions:   make(map[*moqtransport.Session]uint32),
 	}
 	return h.runServer(context.TODO())
 }
@@ -121,6 +122,7 @@ func runClient(opts *options) error {
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
 		publishers: make(map[moqtransport.Publisher]struct{}),
+		sessions:   make(map[*moqtransport.Session]uint32),
 	}
 	return h.runClient(context.TODO(), opts.webtransport)
 }

--- a/fetch_response_writer.go
+++ b/fetch_response_writer.go
@@ -7,6 +7,10 @@ type fetchResponseWriter struct {
 	handled    bool
 }
 
+func (f *fetchResponseWriter) Session() *Session {
+	return f.session
+}
+
 // Accept implements ResponseWriter.
 func (f *fetchResponseWriter) Accept() error {
 	f.handled = true

--- a/handler.go
+++ b/handler.go
@@ -50,6 +50,9 @@ type ResponseWriter interface {
 
 	// Reject sends a negative response to a message.
 	Reject(code uint64, reason string) error
+
+	// Session returns the session associated with this response writer.
+	Session() *Session
 }
 
 // Publisher is the interface implemented by ResponseWriters of Subscribe

--- a/remote_track.go
+++ b/remote_track.go
@@ -36,6 +36,17 @@ type RemoteTrack struct {
 	fetchCount    atomic.Uint64 // should never grow larger than one for now.
 
 	responseChan chan error
+
+	subscribeID uint64
+	trackAlias  uint64
+}
+
+func (t *RemoteTrack) SubscribeID() uint64 {
+	return t.subscribeID
+}
+
+func (t *RemoteTrack) TrackAlias() uint64 {
+	return t.trackAlias
 }
 
 func newRemoteTrack() *RemoteTrack {

--- a/session.go
+++ b/session.go
@@ -299,6 +299,8 @@ func (s *Session) Subscribe(
 		}
 		return nil, err
 	}
+	rt.subscribeID = id
+	rt.trackAlias = alias
 	rt.onUnsubscribe(func() error {
 		return s.unsubscribe(id)
 	})

--- a/subscription_response_writer.go
+++ b/subscription_response_writer.go
@@ -8,6 +8,11 @@ type subscriptionResponseWriter struct {
 	handled    bool
 }
 
+// Session returns the session associated with this response writer.
+func (w *subscriptionResponseWriter) Session() *Session {
+	return w.session
+}
+
 func (w *subscriptionResponseWriter) Accept() error {
 	w.handled = true
 	if err := w.session.acceptSubscription(w.id); err != nil {

--- a/subscription_response_writer.go
+++ b/subscription_response_writer.go
@@ -10,7 +10,7 @@ type subscriptionResponseWriter struct {
 
 // SubscriptionResponseWriter provides extra methods for handling subscription requests.
 type SubscriptionResponseWriter interface {
-	SubscriptionID() uint64
+	SubscribeID() uint64
 	TrackAlias() uint64
 	ResponseWriter
 }
@@ -20,8 +20,8 @@ func (w *subscriptionResponseWriter) Session() *Session {
 	return w.session
 }
 
-// SubscriptionID returns the subscription ID of the subscription request.
-func (w *subscriptionResponseWriter) SubscriptionID() uint64 {
+// SubscribeID returns the subscribeID of the subscription request.
+func (w *subscriptionResponseWriter) SubscribeID() uint64 {
 	return w.id
 }
 

--- a/subscription_response_writer.go
+++ b/subscription_response_writer.go
@@ -8,9 +8,26 @@ type subscriptionResponseWriter struct {
 	handled    bool
 }
 
+// SubscriptionResponseWriter provides extra methods for handling subscription requests.
+type SubscriptionResponseWriter interface {
+	SubscriptionID() uint64
+	TrackAlias() uint64
+	ResponseWriter
+}
+
 // Session returns the session associated with this response writer.
 func (w *subscriptionResponseWriter) Session() *Session {
 	return w.session
+}
+
+// SubscriptionID returns the subscription ID of the subscription request.
+func (w *subscriptionResponseWriter) SubscriptionID() uint64 {
+	return w.id
+}
+
+// TrackAlias returns the track alias of the subscription request.
+func (w *subscriptionResponseWriter) TrackAlias() uint64 {
+	return w.trackAlias
 }
 
 func (w *subscriptionResponseWriter) Accept() error {

--- a/track_status_response_writer.go
+++ b/track_status_response_writer.go
@@ -6,6 +6,11 @@ type trackStatusResponseWriter struct {
 	status  TrackStatus
 }
 
+// Session returns the session associated with this response writer.
+func (w *trackStatusResponseWriter) Session() *Session {
+	return w.session
+}
+
 // Accept commits the status and sends a response to the peer.
 func (w *trackStatusResponseWriter) Accept() error {
 	w.handled = true


### PR DESCRIPTION
To prepare for seamless track switching, this PR adds interfaces to access Session, SubscribeID, and TrackAlias.
The example has also been updated to use these new methods.

I think one should consider doing something different than the current type conversion in the example
between `Publisher` and `SubscriptionResponseWriter` since they both lead back to `subscriptionResponseWriter`.
Maybe extend one of the interfaces to include the other?
