### PR TITLE
fix: parameter order to newRequestIDGenerator

### DIFF
--- a/session.go
+++ b/session.go
@@ -80,7 +80,7 @@ func NewSession(proto Protocol, perspective Perspective, initMaxRequestID uint64
 		ctrlMsgReceiveQueue:                      newQueue[*Message](),
 		version:                                  0,
 		path:                                     "",
-		requestIDs:                               newRequestIDGenerator(uint64(perspective), 2, 0),
+		requestIDs:                               newRequestIDGenerator(uint64(perspective), 0 /*max*/, 2 /*step*/),
 		outgoingAnnouncements:                    newAnnouncementMap(),
 		incomingAnnouncements:                    newAnnouncementMap(),
 		pendingOutgointAnnouncementSubscriptions: newAnnouncementSubscriptionMap(),


### PR DESCRIPTION
The parameters to `newRequestIDGenerator(initialID, maxID, interval uint64)`
where `perspective, 2, 0` with the last two swapped. The interval of `0` meant that
the request ID were not growing when calling `next()`
