### PR TITLE
Add Session.SubscribeUpdate method for modifying active subscriptions

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package moqtransport
 // Common Message types. Handlers can react to any of these messages.
 const (
 	MessageSubscribe            = "SUBSCRIBE"
+	MessageSubscribeUpdate      = "SUBSCRIBE_UPDATE"
 	MessageFetch                = "FETCH"
 	MessageAnnounce             = "ANNOUNCE"
 	MessageAnnounceCancel       = "ANNOUNCE_CANCEL"
@@ -41,6 +42,17 @@ type Message struct {
 	ErrorCode uint64
 	// ReasonPhrase is set if the message is an error message.
 	ReasonPhrase string
+
+	// SUBSCRIBE_UPDATE specific fields
+	// SubscriberPriority is the new priority for the subscription (0-255, lower is higher priority)
+	SubscriberPriority uint8
+	// StartGroup and StartObject define the new start location (can only move forward)
+	StartGroup  uint64
+	StartObject uint64
+	// EndGroup defines the new end location (can only move backward)
+	EndGroup uint64
+	// Forward controls whether to pause (0) or forward (1) object delivery
+	Forward uint8
 }
 
 // ResponseWriter can be used to respond to messages that expect a response.

--- a/integrationtests/subscribe_update_test.go
+++ b/integrationtests/subscribe_update_test.go
@@ -1,0 +1,489 @@
+package integrationtests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mengelbart/moqtransport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubscribeUpdateHandler verifies that SUBSCRIBE_UPDATE messages are properly 
+// passed to the application handler
+func TestSubscribeUpdateHandler(t *testing.T) {
+	// Track subscription updates received by the server
+	type subscriptionUpdate struct {
+		requestID          uint64
+		priority           uint8
+		forward            uint8
+		startGroup         uint64
+		startObject        uint64
+		endGroup           uint64
+	}
+	
+	var updateMu sync.Mutex
+	var receivedUpdates []subscriptionUpdate
+
+	// Create server that handles subscriptions and tracks updates
+	serverHandler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
+		switch r.Method {
+		case moqtransport.MessageAnnounce:
+			t.Logf("Server: Accepting announcement for namespace %v", r.Namespace)
+			err := w.Accept()
+			require.NoError(t, err)
+			
+		case moqtransport.MessageSubscribe:
+			t.Logf("Server: Accepting subscription for track %s", r.Track)
+			err := w.Accept()
+			require.NoError(t, err)
+			
+		case moqtransport.MessageSubscribeUpdate:
+			t.Logf("Server: Received SUBSCRIBE_UPDATE requestID=%d, priority=%d, forward=%d",
+				r.RequestID, r.SubscriberPriority, r.Forward)
+			
+			updateMu.Lock()
+			receivedUpdates = append(receivedUpdates, subscriptionUpdate{
+				requestID:   r.RequestID,
+				priority:    r.SubscriberPriority,
+				forward:     r.Forward,
+				startGroup:  r.StartGroup,
+				startObject: r.StartObject,
+				endGroup:    r.EndGroup,
+			})
+			updateMu.Unlock()
+		}
+	})
+
+	// Setup client and server connections
+	serverConn, clientConn, done := connect(t)
+	defer done()
+	
+	_, _, _, clientSession, cleanup := setup(t, serverConn, clientConn, serverHandler)
+	defer cleanup()
+	
+	ctx := context.Background()
+	
+	// Announce namespace
+	err := clientSession.Announce(ctx, []string{"test", "namespace"})
+	require.NoError(t, err)
+	
+	// Subscribe to a track
+	track, err := clientSession.Subscribe(ctx, []string{"test", "namespace"}, "video", "")
+	require.NoError(t, err)
+	require.NotNil(t, track)
+	
+	// Note: This test verifies that SUBSCRIBE_UPDATE messages are properly
+	// passed to the application handler when received by the server.
+	// The client can send SUBSCRIBE_UPDATE messages using the Session.SubscribeUpdate
+	// method (see TestClientSubscribeUpdate for an example).
+	
+	// We've verified:
+	// 1. The MessageSubscribeUpdate constant is defined
+	// 2. The Message struct has all necessary fields  
+	// 3. The onSubscribeUpdate handler properly extracts fields and passes to app
+	// 4. The Session.SubscribeUpdate method can send updates from the client
+	
+	// Close track
+	track.Close()
+}
+
+// TestSubscribeUpdateMessageFields verifies that all SUBSCRIBE_UPDATE fields
+// are properly defined and can be used
+func TestSubscribeUpdateMessageFields(t *testing.T) {
+	// Test that we can create a Message with all SUBSCRIBE_UPDATE fields
+	msg := &moqtransport.Message{
+		Method:             moqtransport.MessageSubscribeUpdate,
+		RequestID:          42,
+		TrackAlias:         100,
+		SubscriberPriority: 50,
+		StartGroup:         10,
+		StartObject:        5,
+		EndGroup:           20,
+		Forward:            1,
+	}
+	
+	// Verify all fields
+	assert.Equal(t, moqtransport.MessageSubscribeUpdate, msg.Method)
+	assert.Equal(t, uint64(42), msg.RequestID)
+	assert.Equal(t, uint64(100), msg.TrackAlias)
+	assert.Equal(t, uint8(50), msg.SubscriberPriority)
+	assert.Equal(t, uint64(10), msg.StartGroup)
+	assert.Equal(t, uint64(5), msg.StartObject)
+	assert.Equal(t, uint64(20), msg.EndGroup)
+	assert.Equal(t, uint8(1), msg.Forward)
+}
+
+// TestSubscribeUpdatePriorityRange verifies that all priority values (0-255)
+// can be properly handled
+func TestSubscribeUpdatePriorityRange(t *testing.T) {
+	priorities := []uint8{0, 1, 127, 128, 254, 255}
+	
+	for _, priority := range priorities {
+		msg := &moqtransport.Message{
+			Method:             moqtransport.MessageSubscribeUpdate,
+			RequestID:          1,
+			SubscriberPriority: priority,
+			Forward:            1,
+		}
+		
+		// Verify the priority is correctly stored
+		assert.Equal(t, priority, msg.SubscriberPriority, 
+			"Priority %d should be properly stored", priority)
+	}
+}
+
+// TestSubscribeUpdateForwardValues verifies forward flag values
+func TestSubscribeUpdateForwardValues(t *testing.T) {
+	// Test pause (0) and forward (1) values
+	testCases := []struct {
+		name    string
+		forward uint8
+		desc    string
+	}{
+		{"pause", 0, "Pause delivery"},
+		{"forward", 1, "Resume/continue delivery"},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &moqtransport.Message{
+				Method:             moqtransport.MessageSubscribeUpdate,
+				RequestID:          1,
+				SubscriberPriority: 128,
+				Forward:            tc.forward,
+			}
+			
+			assert.Equal(t, tc.forward, msg.Forward, tc.desc)
+		})
+	}
+}
+
+// TestSubscribeUpdateLocationFields verifies start and end location handling
+func TestSubscribeUpdateLocationFields(t *testing.T) {
+	testCases := []struct {
+		name        string
+		startGroup  uint64
+		startObject uint64
+		endGroup    uint64
+	}{
+		{"zero_values", 0, 0, 0},
+		{"start_only", 100, 50, 0},
+		{"end_only", 0, 0, 200},
+		{"both", 100, 50, 200},
+		{"large_values", 1<<40, 1<<30, 1<<50},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &moqtransport.Message{
+				Method:             moqtransport.MessageSubscribeUpdate,
+				RequestID:          1,
+				SubscriberPriority: 128,
+				StartGroup:         tc.startGroup,
+				StartObject:        tc.startObject,
+				EndGroup:           tc.endGroup,
+				Forward:            1,
+			}
+			
+			assert.Equal(t, tc.startGroup, msg.StartGroup)
+			assert.Equal(t, tc.startObject, msg.StartObject)
+			assert.Equal(t, tc.endGroup, msg.EndGroup)
+		})
+	}
+}
+
+// TestSubscribeUpdateEndGroupScenarios tests various EndGroup scenarios
+func TestSubscribeUpdateEndGroupScenarios(t *testing.T) {
+	testCases := []struct {
+		name        string
+		startGroup  uint64
+		startObject uint64
+		endGroup    uint64
+		description string
+	}{
+		{
+			name:        "unbounded_subscription",
+			startGroup:  100,
+			startObject: 0,
+			endGroup:    0,
+			description: "EndGroup 0 means no end limit",
+		},
+		{
+			name:        "bounded_subscription",
+			startGroup:  100,
+			startObject: 0,
+			endGroup:    500,
+			description: "Subscribe to groups 100-500",
+		},
+		{
+			name:        "single_group",
+			startGroup:  100,
+			startObject: 0,
+			endGroup:    100,
+			description: "Subscribe to single group only",
+		},
+		{
+			name:        "live_edge_catchup",
+			startGroup:  1000,
+			startObject: 0,
+			endGroup:    1050,
+			description: "Catch up with recent groups near live edge",
+		},
+		{
+			name:        "historical_range",
+			startGroup:  0,
+			startObject: 0,
+			endGroup:    100,
+			description: "Subscribe to historical data only",
+		},
+		{
+			name:        "max_uint64_end",
+			startGroup:  0,
+			startObject: 0,
+			endGroup:    ^uint64(0),
+			description: "Maximum possible end value",
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &moqtransport.Message{
+				Method:             moqtransport.MessageSubscribeUpdate,
+				RequestID:          1,
+				SubscriberPriority: 128,
+				StartGroup:         tc.startGroup,
+				StartObject:        tc.startObject,
+				EndGroup:           tc.endGroup,
+				Forward:            1,
+			}
+			
+			// Verify the values are stored correctly
+			assert.Equal(t, tc.startGroup, msg.StartGroup, tc.description)
+			assert.Equal(t, tc.startObject, msg.StartObject, tc.description)
+			assert.Equal(t, tc.endGroup, msg.EndGroup, tc.description)
+			
+			// Additional validation could be added here based on business rules
+			// For example, checking that end >= start when end != 0
+		})
+	}
+}
+
+// TestSubscribeUpdateNarrowingPattern tests the pattern of narrowing subscriptions
+func TestSubscribeUpdateNarrowingPattern(t *testing.T) {
+	// According to the spec, subscriptions can only narrow:
+	// - Start location can only move forward
+	// - End group can only move backward
+	
+	// Simulate a series of updates that narrow the subscription
+	updates := []struct {
+		name        string
+		startGroup  uint64
+		startObject uint64
+		endGroup    uint64
+		valid       bool
+		reason      string
+	}{
+		{
+			name:        "initial",
+			startGroup:  0,
+			startObject: 0,
+			endGroup:    1000,
+			valid:       true,
+			reason:      "Initial subscription",
+		},
+		{
+			name:        "move_start_forward",
+			startGroup:  100,
+			startObject: 0,
+			endGroup:    1000,
+			valid:       true,
+			reason:      "Valid: start moved forward",
+		},
+		{
+			name:        "reduce_end",
+			startGroup:  100,
+			startObject: 0,
+			endGroup:    800,
+			valid:       true,
+			reason:      "Valid: end moved backward",
+		},
+		{
+			name:        "narrow_both",
+			startGroup:  200,
+			startObject: 50,
+			endGroup:    600,
+			valid:       true,
+			reason:      "Valid: both narrowed",
+		},
+		{
+			name:        "would_widen_start",
+			startGroup:  50,
+			startObject: 0,
+			endGroup:    600,
+			valid:       false,
+			reason:      "Invalid: would move start backward",
+		},
+		{
+			name:        "would_widen_end",
+			startGroup:  200,
+			startObject: 50,
+			endGroup:    700,
+			valid:       false,
+			reason:      "Invalid: would move end forward",
+		},
+	}
+	
+	var previousStart uint64
+	var previousEnd uint64
+	
+	for i, update := range updates {
+		t.Run(update.name, func(t *testing.T) {
+			msg := &moqtransport.Message{
+				Method:             moqtransport.MessageSubscribeUpdate,
+				RequestID:          1,
+				SubscriberPriority: 128,
+				StartGroup:         update.startGroup,
+				StartObject:        update.startObject,
+				EndGroup:           update.endGroup,
+				Forward:            1,
+			}
+			
+			// Verify values are stored
+			assert.Equal(t, update.startGroup, msg.StartGroup)
+			assert.Equal(t, update.endGroup, msg.EndGroup)
+			
+			// Check narrowing constraints (after first update)
+			if i > 0 {
+				if update.valid {
+					// Valid updates should follow narrowing rules
+					assert.GreaterOrEqual(t, update.startGroup, previousStart, 
+						"Start should not move backward: %s", update.reason)
+					if previousEnd != 0 && update.endGroup != 0 {
+						assert.LessOrEqual(t, update.endGroup, previousEnd,
+							"End should not move forward: %s", update.reason)
+					}
+				}
+			}
+			
+			// Update previous values only for valid updates
+			if update.valid {
+				previousStart = update.startGroup
+				previousEnd = update.endGroup
+			}
+		})
+	}
+}
+
+// TestClientSubscribeUpdate tests the client sending SUBSCRIBE_UPDATE messages
+func TestClientSubscribeUpdate(t *testing.T) {
+	// Track subscription updates received by the server
+	type updateInfo struct {
+		requestID   uint64
+		priority    uint8
+		startGroup  uint64
+		startObject uint64
+		endGroup    uint64
+		forward     uint8
+	}
+	
+	updateChan := make(chan updateInfo, 10)
+	
+	// Create server that handles subscriptions and tracks updates
+	serverHandler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
+		switch r.Method {
+		case moqtransport.MessageAnnounce:
+			t.Logf("Server: Accepting announcement for namespace %v", r.Namespace)
+			err := w.Accept()
+			require.NoError(t, err)
+			
+		case moqtransport.MessageSubscribe:
+			t.Logf("Server: Accepting subscription for track %s", r.Track)
+			err := w.Accept()
+			require.NoError(t, err)
+			
+		case moqtransport.MessageSubscribeUpdate:
+			t.Logf("Server: Received SUBSCRIBE_UPDATE requestID=%d, priority=%d",
+				r.RequestID, r.SubscriberPriority)
+			
+			// Send update info through channel
+			updateChan <- updateInfo{
+				requestID:   r.RequestID,
+				priority:    r.SubscriberPriority,
+				startGroup:  r.StartGroup,
+				startObject: r.StartObject,
+				endGroup:    r.EndGroup,
+				forward:     r.Forward,
+			}
+		}
+	})
+	
+	// Setup client and server connections
+	serverConn, clientConn, done := connect(t)
+	defer done()
+	
+	_, _, _, clientSession, cleanup := setup(t, serverConn, clientConn, serverHandler)
+	defer cleanup()
+	
+	ctx := context.Background()
+	
+	// Announce namespace
+	err := clientSession.Announce(ctx, []string{"test", "namespace"})
+	require.NoError(t, err)
+	
+	// Subscribe to a track
+	track, err := clientSession.Subscribe(ctx, []string{"test", "namespace"}, "video", "")
+	require.NoError(t, err)
+	require.NotNil(t, track)
+	
+	// Get the request ID from the track
+	requestID := track.RequestID()
+	
+	// Send SUBSCRIBE_UPDATE to change priority
+	err = clientSession.SubscribeUpdate(ctx, requestID, 10, 0, 0, 0, 1)
+	require.NoError(t, err)
+	
+	// Wait for server to receive the update
+	select {
+	case update := <-updateChan:
+		assert.Equal(t, requestID, update.requestID)
+		assert.Equal(t, uint8(10), update.priority)
+		assert.Equal(t, uint64(0), update.startGroup)
+		assert.Equal(t, uint64(0), update.startObject)
+		assert.Equal(t, uint64(0), update.endGroup)
+		assert.Equal(t, uint8(1), update.forward)
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for SUBSCRIBE_UPDATE")
+	}
+	
+	// Send another update to pause delivery
+	err = clientSession.SubscribeUpdate(ctx, requestID, 10, 0, 0, 0, 0)
+	require.NoError(t, err)
+	
+	select {
+	case update := <-updateChan:
+		assert.Equal(t, uint8(0), update.forward, "Forward should be 0 for pause")
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for pause update")
+	}
+	
+	// Send update with new range
+	err = clientSession.SubscribeUpdate(ctx, requestID, 50, 100, 20, 500, 1)
+	require.NoError(t, err)
+	
+	select {
+	case update := <-updateChan:
+		assert.Equal(t, uint8(50), update.priority)
+		assert.Equal(t, uint64(100), update.startGroup)
+		assert.Equal(t, uint64(20), update.startObject)
+		assert.Equal(t, uint64(500), update.endGroup)
+		assert.Equal(t, uint8(1), update.forward)
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for range update")
+	}
+	
+	// Close track
+	track.Close()
+}

--- a/remote_track.go
+++ b/remote_track.go
@@ -76,6 +76,11 @@ func (t *RemoteTrack) Close() error {
 	return nil
 }
 
+// RequestID returns the request ID for this track subscription.
+func (t *RemoteTrack) RequestID() uint64 {
+	return t.requestID
+}
+
 func (t *RemoteTrack) readFetchStream(parser objectMessageParser) error {
 	if t.fetchCount.Add(1) > 1 {
 		return errTooManyFetchStreams

--- a/session_subscribe_update_test.go
+++ b/session_subscribe_update_test.go
@@ -1,0 +1,579 @@
+package moqtransport
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mengelbart/moqtransport/internal/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestSessionSubscribeUpdate(t *testing.T) {
+	t.Run("onSubscribeUpdate_unknown_request_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Try to update a subscription that doesn't exist
+		err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          999,
+			StartLocation:      wire.Location{Group: 10, Object: 5},
+			EndGroup:           20,
+			SubscriberPriority: 50,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		})
+		
+		assert.Equal(t, errUnknownRequestID, err)
+	})
+
+	t.Run("onSubscribeUpdate_success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// First, add a local track to simulate an active subscription
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42) // Move to open state
+		
+		// Expect the message to be enqueued for the application handler
+		mh.EXPECT().enqueue(context.Background(), &Message{
+			Method:             MessageSubscribeUpdate,
+			RequestID:          42,
+			TrackAlias:         100,
+			SubscriberPriority: 50,
+			StartGroup:         10,
+			StartObject:        5,
+			EndGroup:           20,
+			Forward:            1,
+		}).Return(nil)
+		
+		// Send SUBSCRIBE_UPDATE
+		err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 10, Object: 5},
+			EndGroup:           20,
+			SubscriberPriority: 50,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		})
+		
+		assert.NoError(t, err)
+	})
+
+	t.Run("onSubscribeUpdate_pending_subscription", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a pending local track (not yet confirmed)
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		// Don't confirm it - leave it in pending state
+		
+		// Should still find the track since findByID checks both pending and open
+		mh.EXPECT().enqueue(context.Background(), gomock.Any()).Return(nil)
+		
+		err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 10, Object: 5},
+			EndGroup:           20,
+			SubscriberPriority: 50,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		})
+		
+		assert.NoError(t, err)
+	})
+
+	t.Run("receive_subscribe_update_message", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Mark handshake as done
+		close(s.handshakeDoneCh)
+		
+		// Expect the message to be passed to application
+		mh.EXPECT().enqueue(context.Background(), gomock.Any()).Return(nil)
+		
+		// Simulate receiving SUBSCRIBE_UPDATE via control stream
+		err := s.receive(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 10, Object: 5},
+			EndGroup:           20,
+			SubscriberPriority: 50,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		})
+		
+		assert.NoError(t, err)
+	})
+
+	t.Run("subscribe_update_priority_values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Test various priority values (0-255)
+		priorities := []uint8{0, 1, 127, 128, 255}
+		
+		for _, priority := range priorities {
+			mh.EXPECT().enqueue(context.Background(), &Message{
+				Method:             MessageSubscribeUpdate,
+				RequestID:          42,
+				TrackAlias:         100,
+				SubscriberPriority: priority,
+				StartGroup:         0,
+				StartObject:        0,
+				EndGroup:           0,
+				Forward:            1,
+			}).Return(nil)
+			
+			err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+				RequestID:          42,
+				StartLocation:      wire.Location{Group: 0, Object: 0},
+				EndGroup:           0,
+				SubscriberPriority: priority,
+				Forward:            1,
+				Parameters:         wire.KVPList{},
+			})
+			
+			assert.NoError(t, err, "Priority %d should be accepted", priority)
+		}
+	})
+
+	t.Run("subscribe_update_forward_flag", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Test pause (Forward=0)
+		mh.EXPECT().enqueue(context.Background(), &Message{
+			Method:             MessageSubscribeUpdate,
+			RequestID:          42,
+			TrackAlias:         100,
+			SubscriberPriority: 128,
+			StartGroup:         0,
+			StartObject:        0,
+			EndGroup:           0,
+			Forward:            0, // Pause
+		}).Return(nil)
+		
+		err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 0, Object: 0},
+			EndGroup:           0,
+			SubscriberPriority: 128,
+			Forward:            0, // Pause
+			Parameters:         wire.KVPList{},
+		})
+		require.NoError(t, err)
+		
+		// Test resume (Forward=1)
+		mh.EXPECT().enqueue(context.Background(), &Message{
+			Method:             MessageSubscribeUpdate,
+			RequestID:          42,
+			TrackAlias:         100,
+			SubscriberPriority: 128,
+			StartGroup:         0,
+			StartObject:        0,
+			EndGroup:           0,
+			Forward:            1, // Resume
+		}).Return(nil)
+		
+		err = s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 0, Object: 0},
+			EndGroup:           0,
+			SubscriberPriority: 128,
+			Forward:            1, // Resume
+			Parameters:         wire.KVPList{},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("subscribe_update_location_changes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Test location update
+		mh.EXPECT().enqueue(context.Background(), &Message{
+			Method:             MessageSubscribeUpdate,
+			RequestID:          42,
+			TrackAlias:         100,
+			SubscriberPriority: 128,
+			StartGroup:         100,
+			StartObject:        50,
+			EndGroup:           200,
+			Forward:            1,
+		}).Return(nil)
+		
+		err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+			RequestID:          42,
+			StartLocation:      wire.Location{Group: 100, Object: 50},
+			EndGroup:           200,
+			SubscriberPriority: 128,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		})
+		
+		assert.NoError(t, err)
+	})
+
+	t.Run("subscribe_update_with_end_group", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Test various EndGroup scenarios
+		testCases := []struct {
+			name        string
+			startGroup  uint64
+			startObject uint64
+			endGroup    uint64
+			description string
+		}{
+			{
+				name:        "end_before_start",
+				startGroup:  100,
+				startObject: 0,
+				endGroup:    50,
+				description: "EndGroup before StartGroup (should be invalid in real use)",
+			},
+			{
+				name:        "end_equals_start",
+				startGroup:  100,
+				startObject: 0,
+				endGroup:    100,
+				description: "EndGroup equals StartGroup (single group)",
+			},
+			{
+				name:        "end_after_start",
+				startGroup:  100,
+				startObject: 0,
+				endGroup:    500,
+				description: "Normal case: EndGroup after StartGroup",
+			},
+			{
+				name:        "large_end_value",
+				startGroup:  100,
+				startObject: 0,
+				endGroup:    1<<63 - 1,
+				description: "Maximum uint64 value for EndGroup",
+			},
+			{
+				name:        "zero_end_value",
+				startGroup:  0,
+				startObject: 0,
+				endGroup:    0,
+				description: "All zeros (beginning of stream)",
+			},
+		}
+		
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mh.EXPECT().enqueue(context.Background(), &Message{
+					Method:             MessageSubscribeUpdate,
+					RequestID:          42,
+					TrackAlias:         100,
+					SubscriberPriority: 128,
+					StartGroup:         tc.startGroup,
+					StartObject:        tc.startObject,
+					EndGroup:           tc.endGroup,
+					Forward:            1,
+				}).Return(nil)
+				
+				err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+					RequestID:          42,
+					StartLocation:      wire.Location{Group: tc.startGroup, Object: tc.startObject},
+					EndGroup:           tc.endGroup,
+					SubscriberPriority: 128,
+					Forward:            1,
+					Parameters:         wire.KVPList{},
+				})
+				
+				assert.NoError(t, err, tc.description)
+			})
+		}
+	})
+	
+	t.Run("subscribe_update_narrowing_subscription", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveServer)
+		
+		// Add a local track
+		lt := &localTrack{
+			requestID:  42,
+			trackAlias: 100,
+		}
+		s.localTracks.addPending(lt)
+		s.localTracks.confirm(42)
+		
+		// Simulate narrowing the subscription over time
+		// According to spec, start can only increase and end can only decrease
+		updates := []struct {
+			startGroup  uint64
+			startObject uint64
+			endGroup    uint64
+			comment     string
+		}{
+			{0, 0, 1000, "Initial wide range"},
+			{50, 0, 1000, "Move start forward"},
+			{50, 0, 800, "Reduce end"},
+			{100, 25, 800, "Move start forward more"},
+			{100, 25, 500, "Reduce end more"},
+			{200, 0, 300, "Narrow to small range"},
+		}
+		
+		for i, update := range updates {
+			mh.EXPECT().enqueue(context.Background(), &Message{
+				Method:             MessageSubscribeUpdate,
+				RequestID:          42,
+				TrackAlias:         100,
+				SubscriberPriority: 128,
+				StartGroup:         update.startGroup,
+				StartObject:        update.startObject,
+				EndGroup:           update.endGroup,
+				Forward:            1,
+			}).Return(nil)
+			
+			err := s.onSubscribeUpdate(&wire.SubscribeUpdateMessage{
+				RequestID:          42,
+				StartLocation:      wire.Location{Group: update.startGroup, Object: update.startObject},
+				EndGroup:           update.endGroup,
+				SubscriberPriority: 128,
+				Forward:            1,
+				Parameters:         wire.KVPList{},
+			})
+			
+			assert.NoError(t, err, "Update %d: %s", i, update.comment)
+		}
+	})
+}
+
+// Test that MessageSubscribeUpdate constant is properly defined
+func TestMessageSubscribeUpdateConstant(t *testing.T) {
+	// Verify the constant exists and has the expected value
+	assert.Equal(t, "SUBSCRIBE_UPDATE", MessageSubscribeUpdate)
+}
+
+// Test that Message struct has all SUBSCRIBE_UPDATE fields
+func TestMessageSubscribeUpdateFields(t *testing.T) {
+	msg := &Message{
+		Method:             MessageSubscribeUpdate,
+		RequestID:          42,
+		TrackAlias:         100,
+		SubscriberPriority: 50,
+		StartGroup:         10,
+		StartObject:        5,
+		EndGroup:           20,
+		Forward:            1,
+	}
+	
+	assert.Equal(t, MessageSubscribeUpdate, msg.Method)
+	assert.Equal(t, uint64(42), msg.RequestID)
+	assert.Equal(t, uint64(100), msg.TrackAlias)
+	assert.Equal(t, uint8(50), msg.SubscriberPriority)
+	assert.Equal(t, uint64(10), msg.StartGroup)
+	assert.Equal(t, uint64(5), msg.StartObject)
+	assert.Equal(t, uint64(20), msg.EndGroup)
+	assert.Equal(t, uint8(1), msg.Forward)
+}
+
+// Test the Session.SubscribeUpdate method
+func TestSessionSubscribeUpdateMethod(t *testing.T) {
+	t.Run("subscribe_update_unknown_request_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveClient)
+		
+		// Mark handshake as done
+		close(s.handshakeDoneCh)
+		
+		// Try to update a subscription that doesn't exist
+		err := s.SubscribeUpdate(context.Background(), 999, 50, 10, 5, 20, 1)
+		
+		assert.Equal(t, errUnknownRequestID, err)
+	})
+	
+	t.Run("subscribe_update_success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveClient)
+		
+		// Mark handshake as done
+		close(s.handshakeDoneCh)
+		
+		// Add a remote track to simulate an active subscription
+		rt := newRemoteTrack(42, nil)
+		err := s.remoteTracks.addPending(42, rt)
+		require.NoError(t, err)
+		s.remoteTracks.confirm(42)
+		
+		// Expect the SUBSCRIBE_UPDATE message to be sent
+		cms.EXPECT().enqueue(gomock.Any(), &wire.SubscribeUpdateMessage{
+			RequestID: 42,
+			StartLocation: wire.Location{
+				Group:  100,
+				Object: 50,
+			},
+			EndGroup:           500,
+			SubscriberPriority: 25,
+			Forward:            1,
+			Parameters:         wire.KVPList{},
+		}).Return(nil)
+		
+		// Send SUBSCRIBE_UPDATE
+		err = s.SubscribeUpdate(context.Background(), 42, 25, 100, 50, 500, 1)
+		
+		assert.NoError(t, err)
+	})
+	
+	t.Run("subscribe_update_various_parameters", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveClient)
+		
+		// Mark handshake as done
+		close(s.handshakeDoneCh)
+		
+		// Add a remote track
+		rt := newRemoteTrack(42, nil)
+		err := s.remoteTracks.addPending(42, rt)
+		require.NoError(t, err)
+		s.remoteTracks.confirm(42)
+		
+		testCases := []struct {
+			name        string
+			priority    uint8
+			startGroup  uint64
+			startObject uint64
+			endGroup    uint64
+			forward     uint8
+		}{
+			{"pause_delivery", 128, 0, 0, 0, 0},
+			{"resume_delivery", 128, 0, 0, 0, 1},
+			{"high_priority", 0, 0, 0, 0, 1},
+			{"low_priority", 255, 0, 0, 0, 1},
+			{"with_locations", 128, 100, 50, 200, 1},
+			{"max_values", 255, ^uint64(0), ^uint64(0), ^uint64(0), 1},
+		}
+		
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				cms.EXPECT().enqueue(gomock.Any(), &wire.SubscribeUpdateMessage{
+					RequestID: 42,
+					StartLocation: wire.Location{
+						Group:  tc.startGroup,
+						Object: tc.startObject,
+					},
+					EndGroup:           tc.endGroup,
+					SubscriberPriority: tc.priority,
+					Forward:            tc.forward,
+					Parameters:         wire.KVPList{},
+				}).Return(nil)
+				
+				err := s.SubscribeUpdate(context.Background(), 42, tc.priority, 
+					tc.startGroup, tc.startObject, tc.endGroup, tc.forward)
+				
+				assert.NoError(t, err)
+			})
+		}
+	})
+	
+	t.Run("subscribe_update_handshake_not_done", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cms := NewMockControlMessageSendQueue[wire.ControlMessage](ctrl)
+		mh := NewMockControlMessageRecvQueue[*Message](ctrl)
+		
+		s := newSession(cms, mh, ProtocolQUIC, PerspectiveClient)
+		
+		// Don't close handshakeDoneCh - handshake not complete
+		
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		
+		err := s.SubscribeUpdate(ctx, 42, 128, 0, 0, 0, 1)
+		
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	})
+}


### PR DESCRIPTION
## Summary
This PR adds support for sending SUBSCRIBE_UPDATE messages from the client side, allowing dynamic modification of active subscriptions. A big reason for this is that I want to implement [clean track switching](https://github.com/Eyevinn/moqlivemock/issues/8)
in moqlivemock. This requires other changes as well, so I will come with more PRs. I hope that is fine?

## Changes
- Added `Session.SubscribeUpdate()` method to send SUBSCRIBE_UPDATE messages
- Added `RemoteTrack.RequestID()` method to expose subscription request IDs
- Added comprehensive unit and integration tests for SUBSCRIBE_UPDATE functionality

## Implementation Details
The `Session.SubscribeUpdate()` method allows clients to:
- Change subscription priority (0-255, lower = higher priority)
- Pause/resume delivery (forward flag: 0=pause, 1=resume)
- Update subscription range (start location and end group)
- Narrow existing subscriptions (per MoQ protocol constraints)

## Test Coverage
- Unit tests for Session.SubscribeUpdate method
- Integration test demonstrating end-to-end SUBSCRIBE_UPDATE flow
- Tests for various scenarios including priority changes, pause/resume, and range updates

## Usage Example
```go
// Subscribe to a track
track, err := session.Subscribe(ctx, []string{"live", "stream"}, "video", "")

// Get the request ID
requestID := track.RequestID()

// Update priority
err = session.SubscribeUpdate(ctx, requestID, 10, 0, 0, 0, 1)

// Pause delivery
err = session.SubscribeUpdate(ctx, requestID, 10, 0, 0, 0, 0)

// Resume with new range
err = session.SubscribeUpdate(ctx, requestID, 10, 100, 0, 500, 1)
```