### PR TITLE
Convert Message from struct to interface with minimal API methods

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -16,12 +16,21 @@ const (
 
 // Message represents a message from the peer that can be handled by the
 // application.
-type Message struct {
+type Message interface {
 	// Method describes the type of the message.
-	Method string
+	Method() string
 
 	// RequestID is set if the message references a request.
-	RequestID uint64
+	RequestID() uint64
+}
+
+// GenericMessage implements the Message interface and contains all fields.
+type GenericMessage struct {
+	// Method describes the type of the message.
+	method string
+
+	// RequestID is set if the message references a request.
+	requestID uint64
 	// TrackAlias corresponding to the subscription.
 	TrackAlias uint64
 
@@ -41,6 +50,16 @@ type Message struct {
 	ErrorCode uint64
 	// ReasonPhrase is set if the message is an error message.
 	ReasonPhrase string
+}
+
+// Method implements Message.
+func (m *GenericMessage) Method() string {
+	return m.method
+}
+
+// RequestID implements Message.
+func (m *GenericMessage) RequestID() uint64 {
+	return m.requestID
 }
 
 // ResponseWriter can be used to respond to messages that expect a response.
@@ -86,13 +105,13 @@ type StatusRequestHandler interface {
 
 // A Handler responds to MoQ messages.
 type Handler interface {
-	Handle(ResponseWriter, *Message)
+	Handle(ResponseWriter, Message)
 }
 
 // HandlerFunc is a type that implements Handler.
-type HandlerFunc func(ResponseWriter, *Message)
+type HandlerFunc func(ResponseWriter, Message)
 
 // Handle implements Handler.
-func (f HandlerFunc) Handle(rw ResponseWriter, r *Message) {
+func (f HandlerFunc) Handle(rw ResponseWriter, r Message) {
 	f(rw, r)
 }

--- a/integrationtests/announce_test.go
+++ b/integrationtests/announce_test.go
@@ -13,8 +13,8 @@ func TestAnnounce(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageAnnounce, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageAnnounce, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 		})
@@ -28,8 +28,8 @@ func TestAnnounce(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageAnnounce, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageAnnounce, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Reject(moqtransport.ErrorCodeAnnouncementInternal, "expected error"))
 		})

--- a/integrationtests/fetch_test.go
+++ b/integrationtests/fetch_test.go
@@ -14,8 +14,8 @@ func TestFetch(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageFetch, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageFetch, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 		})
@@ -30,8 +30,8 @@ func TestFetch(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageFetch, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageFetch, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Reject(moqtransport.ErrorCodeFetchUnauthorized, "unauthorized"))
 		})
@@ -50,8 +50,8 @@ func TestFetch(t *testing.T) {
 
 		publisherCh := make(chan moqtransport.FetchPublisher, 1)
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageFetch, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageFetch, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 			publisher, ok := w.(moqtransport.FetchPublisher)

--- a/integrationtests/subscribe_announces_test.go
+++ b/integrationtests/subscribe_announces_test.go
@@ -13,8 +13,8 @@ func TestSubscribeAnnounces(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribeAnnounces, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribeAnnounces, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 		})

--- a/integrationtests/subscribe_test.go
+++ b/integrationtests/subscribe_test.go
@@ -14,8 +14,8 @@ func TestSubscribe(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribe, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribe, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 		})
@@ -31,8 +31,8 @@ func TestSubscribe(t *testing.T) {
 		sConn, cConn, cancel := connect(t)
 		defer cancel()
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribe, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribe, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Reject(moqtransport.ErrorCodeSubscribeUnauthorized, "unauthorized"))
 		})
@@ -51,8 +51,8 @@ func TestSubscribe(t *testing.T) {
 
 		publisherCh := make(chan moqtransport.Publisher, 1)
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribe, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribe, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 			publisher, ok := w.(moqtransport.Publisher)
@@ -114,8 +114,8 @@ func TestSubscribe(t *testing.T) {
 
 		publisherCh := make(chan moqtransport.Publisher, 1)
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribe, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribe, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 			publisher, ok := w.(moqtransport.Publisher)
@@ -152,8 +152,8 @@ func TestSubscribe(t *testing.T) {
 
 		publisherCh := make(chan moqtransport.Publisher, 1)
 
-		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m *moqtransport.Message) {
-			assert.Equal(t, moqtransport.MessageSubscribe, m.Method)
+		handler := moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, m moqtransport.Message) {
+			assert.Equal(t, moqtransport.MessageSubscribe, m.Method())
 			assert.NotNil(t, w)
 			assert.NoError(t, w.Accept())
 			publisher, ok := w.(moqtransport.Publisher)

--- a/mock_control_message_recv_queue_test.go
+++ b/mock_control_message_recv_queue_test.go
@@ -40,10 +40,10 @@ func (m *MockControlMessageRecvQueue[T]) EXPECT() *MockControlMessageRecvQueueMo
 }
 
 // dequeue mocks base method.
-func (m *MockControlMessageRecvQueue[T]) dequeue(arg0 context.Context) (*Message, error) {
+func (m *MockControlMessageRecvQueue[T]) dequeue(arg0 context.Context) (Message, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "dequeue", arg0)
-	ret0, _ := ret[0].(*Message)
+	ret0, _ := ret[0].(Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -61,25 +61,25 @@ type MockControlMessageRecvQueuedequeueCall[T any] struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControlMessageRecvQueuedequeueCall[T]) Return(arg0 *Message, arg1 error) *MockControlMessageRecvQueuedequeueCall[T] {
+func (c *MockControlMessageRecvQueuedequeueCall[T]) Return(arg0 Message, arg1 error) *MockControlMessageRecvQueuedequeueCall[T] {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControlMessageRecvQueuedequeueCall[T]) Do(f func(context.Context) (*Message, error)) *MockControlMessageRecvQueuedequeueCall[T] {
+func (c *MockControlMessageRecvQueuedequeueCall[T]) Do(f func(context.Context) (Message, error)) *MockControlMessageRecvQueuedequeueCall[T] {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControlMessageRecvQueuedequeueCall[T]) DoAndReturn(f func(context.Context) (*Message, error)) *MockControlMessageRecvQueuedequeueCall[T] {
+func (c *MockControlMessageRecvQueuedequeueCall[T]) DoAndReturn(f func(context.Context) (Message, error)) *MockControlMessageRecvQueuedequeueCall[T] {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // enqueue mocks base method.
-func (m *MockControlMessageRecvQueue[T]) enqueue(arg0 context.Context, arg1 *Message) error {
+func (m *MockControlMessageRecvQueue[T]) enqueue(arg0 context.Context, arg1 Message) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "enqueue", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -105,13 +105,13 @@ func (c *MockControlMessageRecvQueueenqueueCall[T]) Return(arg0 error) *MockCont
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControlMessageRecvQueueenqueueCall[T]) Do(f func(context.Context, *Message) error) *MockControlMessageRecvQueueenqueueCall[T] {
+func (c *MockControlMessageRecvQueueenqueueCall[T]) Do(f func(context.Context, Message) error) *MockControlMessageRecvQueueenqueueCall[T] {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControlMessageRecvQueueenqueueCall[T]) DoAndReturn(f func(context.Context, *Message) error) *MockControlMessageRecvQueueenqueueCall[T] {
+func (c *MockControlMessageRecvQueueenqueueCall[T]) DoAndReturn(f func(context.Context, Message) error) *MockControlMessageRecvQueueenqueueCall[T] {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mockgen.go
+++ b/mockgen.go
@@ -16,7 +16,7 @@ import "github.com/mengelbart/moqtransport/internal/wire"
 type ControlMessageParser = controlMessageParser
 
 //go:generate sh -c "go run go.uber.org/mock/mockgen -build_flags=\"-tags=gomock\" -typed -package moqtransport -write_package_comment=false -self_package github.com/mengelbart/moqtransport -destination mock_control_message_recv_queue_test.go github.com/mengelbart/moqtransport ControlMessageRecvQueue"
-type ControlMessageRecvQueue = controlMessageQueue[*Message]
+type ControlMessageRecvQueue = controlMessageQueue[Message]
 
 //go:generate sh -c "go run go.uber.org/mock/mockgen -build_flags=\"-tags=gomock\" -typed -package moqtransport -write_package_comment=false -self_package github.com/mengelbart/moqtransport -destination mock_control_message_send_test.go github.com/mengelbart/moqtransport ControlMessageSendQueue"
 type ControlMessageSendQueue = controlMessageQueue[wire.ControlMessage]

--- a/transport.go
+++ b/transport.go
@@ -58,9 +58,16 @@ func (t *Transport) Run() error {
 	return nil
 }
 
-func (t *Transport) handleSubscription(m *Message) {
-	lt := newLocalTrack(t.Conn, m.RequestID, m.TrackAlias, func(code, count uint64, reason string) error {
-		return t.Session.subscriptionDone(m.RequestID, code, count, reason)
+func (t *Transport) handleSubscription(m Message) {
+	// Type assert to get access to GenericMessage fields
+	gm, ok := m.(*GenericMessage)
+	if !ok {
+		t.logger.Error("received non-GenericMessage in handleSubscription")
+		return
+	}
+	
+	lt := newLocalTrack(t.Conn, m.RequestID(), gm.TrackAlias, func(code, count uint64, reason string) error {
+		return t.Session.subscriptionDone(m.RequestID(), code, count, reason)
 	}, t.Qlogger)
 
 	if err := t.Session.addLocalTrack(lt); err != nil {
@@ -68,15 +75,15 @@ func (t *Transport) handleSubscription(m *Message) {
 			t.handleProtocolViolation(err)
 			return
 		}
-		if rejectErr := t.Session.rejectSubscription(m.RequestID, ErrorCodeSubscribeInternal, ""); rejectErr != nil {
+		if rejectErr := t.Session.rejectSubscription(m.RequestID(), ErrorCodeSubscribeInternal, ""); rejectErr != nil {
 			t.logger.Error("failed to add localtrack and failed to reject subscription", "error", err, "rejectErr", rejectErr)
 			// TODO: Close conn?
 		}
 		return
 	}
 	srw := &subscriptionResponseWriter{
-		id:         m.RequestID,
-		trackAlias: m.TrackAlias,
+		id:         m.RequestID(),
+		trackAlias: gm.TrackAlias,
 		session:    t.Session,
 		localTrack: lt,
 		handled:    false,
@@ -90,21 +97,28 @@ func (t *Transport) handleSubscription(m *Message) {
 
 }
 
-func (t *Transport) handleFetch(m *Message) {
-	lt := newLocalTrack(t.Conn, m.RequestID, m.TrackAlias, nil, t.Qlogger)
+func (t *Transport) handleFetch(m Message) {
+	// Type assert to get access to GenericMessage fields
+	gm, ok := m.(*GenericMessage)
+	if !ok {
+		t.logger.Error("received non-GenericMessage in handleFetch")
+		return
+	}
+	
+	lt := newLocalTrack(t.Conn, m.RequestID(), gm.TrackAlias, nil, t.Qlogger)
 	if err := t.Session.addLocalTrack(lt); err != nil {
 		if err == errMaxRequestIDViolated || err == errDuplicateRequestID {
 			t.handleProtocolViolation(err)
 			return
 		}
-		if rejectErr := t.Session.rejectFetch(m.RequestID, ErrorCodeSubscribeInternal, ""); rejectErr != nil {
+		if rejectErr := t.Session.rejectFetch(m.RequestID(), ErrorCodeSubscribeInternal, ""); rejectErr != nil {
 			t.logger.Error("failed to add localtrack and failed to reject fetch", "error", err, "rejectErr", rejectErr)
 			// TODO: Close conn?
 		}
 		return
 	}
 	frw := &fetchResponseWriter{
-		id:         m.RequestID,
+		id:         m.RequestID(),
 		session:    t.Session,
 		localTrack: lt,
 		handled:    false,
@@ -117,16 +131,16 @@ func (t *Transport) handleFetch(m *Message) {
 	}
 }
 
-func (t *Transport) handle(m *Message) {
+func (t *Transport) handle(m Message) {
 	if t.Handler != nil {
-		switch m.Method {
+		switch m.Method() {
 		case MessageSubscribe:
 			t.handleSubscription(m)
 		case MessageFetch:
 			t.handleFetch(m)
 		case MessageAnnounce:
 			arw := &announcementResponseWriter{
-				requestID: m.RequestID,
+				requestID: m.RequestID(),
 				session:   t.Session,
 				handled:   false,
 			}
@@ -138,7 +152,7 @@ func (t *Transport) handle(m *Message) {
 			}
 		case MessageSubscribeAnnounces:
 			asrw := &announcementSubscriptionResponseWriter{
-				requestID: m.RequestID,
+				requestID: m.RequestID(),
 				session:   t.Session,
 				handled:   false,
 			}
@@ -149,12 +163,18 @@ func (t *Transport) handle(m *Message) {
 				}
 			}
 		case MessageTrackStatusRequest:
+			// Type assert to get access to GenericMessage fields
+			gm, ok := m.(*GenericMessage)
+			if !ok {
+				t.logger.Error("received non-GenericMessage in MessageTrackStatusRequest")
+				return
+			}
 			tsrw := &trackStatusResponseWriter{
 				session: t.Session,
 				handled: false,
 				status: TrackStatus{
-					Namespace:    m.Namespace,
-					Trackname:    m.Track,
+					Namespace:    gm.Namespace,
+					Trackname:    gm.Track,
 					StatusCode:   0,
 					LastGroupID:  0,
 					LastObjectID: 0,


### PR DESCRIPTION
This is the first step of a refactoring of #224. More PRs will follow, but I think this is a first good step that should be easy to review.

This PR refactors the Message type from a concrete struct to an interface with only two methods: Method() and RequestID(). It does not yet provide details in the API or changes the possibility to send back detailed parameters.

This design enables future specialized message types which will have specific attribute combinations.
One could possibly remove RequestID() from the interface since it may not be present in all messages, but
that would have introduced changes in more places in the code, so I leave that for now.

Key changes:
- Message is now an interface with Method() and RequestID() methods
- GenericMessage struct implements Message interface with all original fields
- All message creation updated to use GenericMessage instances
- Handler signature changed from (*Message) to (Message)
- Tests and integration tests updated to work with new interface
- Mock generation updated