### PR TITLE
Fix integration tests

### DIFF
--- a/integrationtests/utils.go
+++ b/integrationtests/utils.go
@@ -7,7 +7,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"math/big"
+	"net"
 	"sync"
 	"testing"
 
@@ -20,12 +22,12 @@ import (
 func connect(t *testing.T) (server, client quic.Connection, cancel func()) {
 	tlsConfig, err := generateTLSConfig()
 	assert.NoError(t, err)
-	listener, err := quic.ListenAddr("localhost:4242", tlsConfig, &quic.Config{
+	listener, err := quic.ListenAddr("localhost:0", tlsConfig, &quic.Config{
 		EnableDatagrams: true,
 	})
 	assert.NoError(t, err)
 
-	clientConn, err := quic.DialAddr(context.Background(), "localhost:4242", &tls.Config{
+	clientConn, err := quic.DialAddr(context.Background(), fmt.Sprintf("localhost:%d", listener.Addr().(*net.UDPAddr).Port), &tls.Config{
 		InsecureSkipVerify: true,
 		NextProtos:         []string{"moq-00"},
 	}, &quic.Config{


### PR DESCRIPTION
Reduces test failures due to conflicting ports when integration tests run in parallel.