### PR TITLE
Remove SUBSCRIBE message constant

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -2,7 +2,6 @@ package moqtransport
 
 // Common Message types. Handlers can react to any of these messages.
 const (
-	MessageSubscribe            = "SUBSCRIBE"
 	MessageFetch                = "FETCH"
 	MessageAnnounce             = "ANNOUNCE"
 	MessageAnnounceCancel       = "ANNOUNCE_CANCEL"


### PR DESCRIPTION
Remove it to avoid confusion because different handlers seem to be able to handle subscribe messages.