### PR TITLE
Limit qlog payload logging

### DIFF
--- a/fetch_stream.go
+++ b/fetch_stream.go
@@ -64,11 +64,7 @@ func (f *FetchStream) WriteObject(
 			ExtensionHeaders:       nil,
 			ObjectPayloadLength:    uint64(len(payload)),
 			ObjectStatus:           0,
-			ObjectPayload: qlog.RawInfo{
-				Length:        uint64(len(payload)),
-				PayloadLength: uint64(len(payload)),
-				Data:          payload,
-			},
+			ObjectPayload: wire.TruncatedRawInfo(payload),
 		})
 	}
 	return len(payload), nil

--- a/internal/wire/object_stream_parser.go
+++ b/internal/wire/object_stream_parser.go
@@ -179,11 +179,7 @@ func (p *ObjectStreamParser) parseSubgroupObject() (*ObjectMessage, error) {
 			ExtensionHeaders:       eth,
 			ObjectPayloadLength:    uint64(len(m.ObjectPayload)),
 			ObjectStatus:           uint64(m.ObjectStatus),
-			ObjectPayload: qlog.RawInfo{
-				Length:        uint64(len(m.ObjectPayload)),
-				PayloadLength: uint64(len(m.ObjectPayload)),
-				Data:          m.ObjectPayload,
-			},
+			ObjectPayload: TruncatedRawInfo(m.ObjectPayload),
 		})
 	}
 	return m, nil
@@ -225,11 +221,7 @@ func (p *ObjectStreamParser) parseFetchObject() (*ObjectMessage, error) {
 			ExtensionHeaders:       eth,
 			ObjectPayloadLength:    uint64(len(m.ObjectPayload)),
 			ObjectStatus:           uint64(m.ObjectStatus),
-			ObjectPayload: qlog.RawInfo{
-				Length:        uint64(len(m.ObjectPayload)),
-				PayloadLength: uint64(len(m.ObjectPayload)),
-				Data:          m.ObjectPayload,
-			},
+			ObjectPayload: TruncatedRawInfo(m.ObjectPayload),
 		})
 	}
 	return m, nil

--- a/internal/wire/qlog_helpers.go
+++ b/internal/wire/qlog_helpers.go
@@ -1,0 +1,20 @@
+package wire
+
+import "github.com/mengelbart/qlog"
+
+const maxQlogPayloadBytes = 20
+
+// TruncatedRawInfo creates a qlog.RawInfo with the Data field truncated to
+// maxQlogPayloadBytes. The Length and PayloadLength fields reflect the original
+// full length, while Data contains only the first 20 bytes (or less if shorter).
+func TruncatedRawInfo(data []byte) qlog.RawInfo {
+	truncated := data
+	if len(data) > maxQlogPayloadBytes {
+		truncated = data[:maxQlogPayloadBytes]
+	}
+	return qlog.RawInfo{
+		Length:        uint64(len(data)),
+		PayloadLength: uint64(len(data)),
+		Data:          truncated,
+	}
+}

--- a/local_track.go
+++ b/local_track.go
@@ -110,11 +110,7 @@ func (p *localTrack) sendDatagram(o Object) error {
 			ExtensionHeadersLength: uint64(len(om.ObjectExtensionHeaders)),
 			ExtensionHeaders:       eth,
 			ObjectStatus:           uint64(om.ObjectStatus),
-			Payload: qlog.RawInfo{
-				Length:        uint64(len(om.ObjectPayload)),
-				PayloadLength: uint64(len(om.ObjectPayload)),
-				Data:          om.ObjectPayload,
-			},
+			Payload: wire.TruncatedRawInfo(om.ObjectPayload),
 		})
 	}
 	return p.conn.SendDatagram(buf)

--- a/session.go
+++ b/session.go
@@ -216,11 +216,7 @@ func (s *Session) readDatagrams(ctx context.Context) error {
 				ExtensionHeadersLength: uint64(len(msg.ObjectExtensionHeaders)),
 				ExtensionHeaders:       eth,
 				ObjectStatus:           uint64(msg.ObjectStatus),
-				Payload: qlog.RawInfo{
-					Length:        uint64(len(msg.ObjectPayload)),
-					PayloadLength: uint64(len(msg.ObjectPayload)),
-					Data:          msg.ObjectPayload,
-				},
+				Payload:                wire.TruncatedRawInfo(msg.ObjectPayload),
 			})
 		}
 		if err := s.receiveDatagram(msg); err != nil {

--- a/subgroup.go
+++ b/subgroup.go
@@ -73,11 +73,7 @@ func (s *Subgroup) WriteObject(objectID uint64, payload []byte) (int, error) {
 			ExtensionHeaders:       nil,
 			ObjectPayloadLength:    uint64(len(payload)),
 			ObjectStatus:           0,
-			ObjectPayload: qlog.RawInfo{
-				Length:        uint64(len(payload)),
-				PayloadLength: uint64(len(payload)),
-				Data:          payload,
-			},
+			ObjectPayload: wire.TruncatedRawInfo(payload),
 		})
 	}
 	return len(payload), nil


### PR DESCRIPTION
For real media data, the qlog logging of object payload is far too much.
This is a fix to not log more than 20 bytes of payload, but log the full length.
Some other, maybe more configurable,  mechanism is fine as well, but having a limit to payload loggins is definitely valuable.