### PR TITLE
Set TrackAlias in SUBSCRIBE_OK (draft-13 fix)

### DIFF
--- a/session.go
+++ b/session.go
@@ -594,7 +594,7 @@ func (s *Session) UpdateSubscription(ctx context.Context, requestID uint64, opti
 
 // acceptSubscriptionWithOptions accepts a subscription with relevant options.
 func (s *Session) acceptSubscriptionWithOptions(id uint64, opts *SubscribeOkOptions) error {
-	_, ok := s.localTracks.confirm(id)
+	lt, ok := s.localTracks.confirm(id)
 	if !ok {
 		return errUnknownRequestID
 	}
@@ -612,6 +612,7 @@ func (s *Session) acceptSubscriptionWithOptions(id uint64, opts *SubscribeOkOpti
 
 	msg := &wire.SubscribeOkMessage{
 		RequestID:     id,
+		TrackAlias:    lt.trackAlias,
 		Expires:       opts.Expires,
 		GroupOrder:    uint8(opts.GroupOrder),
 		ContentExists: opts.ContentExists,


### PR DESCRIPTION
## Summary

The draft-13 message format update (92fd720) moved TrackAlias assignment from the subscriber (in SUBSCRIBE) to the publisher (in SUBSCRIBE_OK). The `localTrack` correctly receives a publisher-assigned alias via `s.trackAliases.next()`, but `acceptSubscriptionWithOptions` did not copy `lt.trackAlias` into the outgoing `SubscribeOkMessage`. This left `TrackAlias` at its zero value (0) for every SUBSCRIBE_OK, preventing subscribers from correctly dispatching incoming datagrams by alias.

## Change

One line in `session.go`: use the `localTrack` returned by `confirm()` and set `TrackAlias: lt.trackAlias` in the `SubscribeOkMessage`.

## Test plan

- All existing tests pass (`go test ./...`)
- Verified end-to-end with a QUIC client subscribing to 3 tracks: SUBSCRIBE_OK now returns unique aliases (0, 1, 2) instead of all zeros