### PR TITLE
Implement MoQ Session Migration

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package moqtransport
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrorCode is a generic error codes
 type ErrorCode uint64
@@ -146,4 +149,17 @@ var (
 		code:    ErrorCodeProtocolViolation,
 		message: "invalid namespace length",
 	}
+	errMultipleGoAways = ProtocolError{
+		code:    ErrorCodeProtocolViolation,
+		message: "multiple GOAWAY messages received",
+	}
+	errGoAwayWithURIOnServer = ProtocolError{
+		code:    ErrorCodeProtocolViolation,
+		message: "GOAWAY with URI received on server",
+	}
+	errGoAwayURITooLong = ProtocolError{
+		code:    ErrorCodeProtocolViolation,
+		message: "GOAWAY URI length exceeds 8192 bytes",
+	}
+	errSessionDraining = errors.New("session is draining after GOAWAY")
 )

--- a/examples/date/handler.go
+++ b/examples/date/handler.go
@@ -23,6 +23,7 @@ type moqHandler struct {
 	server        bool
 	quic          bool
 	addr          string
+	goawayURI     string
 	tlsConfig     *tls.Config
 	namespace     []string
 	trackname     string
@@ -32,6 +33,8 @@ type moqHandler struct {
 	publishers    map[moqtransport.Publisher]struct{}
 	lock          sync.Mutex
 	largestGroup  atomic.Uint64
+	sessions      map[uint64]*moqtransport.Session
+	sessionsLock  sync.Mutex
 }
 
 func (h *moqHandler) runClient(ctx context.Context, wt bool) error {
@@ -51,7 +54,8 @@ func (h *moqHandler) runClient(ctx context.Context, wt bool) error {
 	if err = h.handle(conn); err != nil {
 		return err
 	}
-	select {}
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (h *moqHandler) runServer(ctx context.Context) error {
@@ -112,6 +116,9 @@ func (h *moqHandler) getHandler(sessionID uint64) moqtransport.Handler {
 				log.Printf("failed to accept announcement: %v", err)
 				return
 			}
+		case moqtransport.MessageGoAway:
+			log.Printf("sessionNr: %d received GOAWAY, new session URI: %v", sessionID, r.NewSessionURI)
+			go h.handleGoAway(sessionID, r.NewSessionURI)
 		}
 	})
 }
@@ -172,6 +179,11 @@ func (h *moqHandler) handle(conn moqtransport.Connection) error {
 	if err := session.Run(conn); err != nil {
 		return err
 	}
+
+	h.sessionsLock.Lock()
+	h.sessions[id] = session
+	h.sessionsLock.Unlock()
+
 	if h.publish {
 		if err := session.Announce(context.Background(), h.namespace); err != nil {
 			log.Printf("faild to announce namespace '%v': %v", h.namespace, err)
@@ -183,6 +195,66 @@ func (h *moqHandler) handle(conn moqtransport.Connection) error {
 		}
 	}
 	return nil
+}
+
+func (h *moqHandler) handleGoAway(oldSessionID uint64, newURI string) {
+	h.sessionsLock.Lock()
+	oldSession, ok := h.sessions[oldSessionID]
+	h.sessionsLock.Unlock()
+	if !ok {
+		log.Printf("GOAWAY: could not find session %d", oldSessionID)
+		return
+	}
+
+	addr := newURI
+	if addr == "" {
+		addr = h.addr
+	}
+
+	log.Printf("GOAWAY: connecting to new relay at %v", addr)
+	var conn moqtransport.Connection
+	var err error
+	if h.quic {
+		conn, err = dialQUIC(context.Background(), addr)
+	} else {
+		conn, err = dialWebTransport(context.Background(), addr)
+	}
+	if err != nil {
+		log.Printf("GOAWAY: failed to dial new relay: %v", err)
+		return
+	}
+
+	newID := h.nextSessionID.Add(1)
+	newSession := &moqtransport.Session{
+		Handler:                h.getHandler(newID),
+		SubscribeHandler:       h.getSubscribeHandler(newID),
+		SubscribeUpdateHandler: h.getSubscribeUpdateHandler(newID),
+		InitialMaxRequestID:    100,
+	}
+
+	go func() {
+		if err := newSession.Run(conn); err != nil {
+			log.Printf("GOAWAY: new session Run failed: %v", err)
+			return
+		}
+
+		h.sessionsLock.Lock()
+		h.sessions[newID] = newSession
+		h.sessionsLock.Unlock()
+
+		log.Printf("GOAWAY: new session %d established, migrating subscriptions", newID)
+		n, err := oldSession.Migrate(newSession)
+		if err != nil {
+			log.Printf("GOAWAY: migration failed: %v", err)
+			return
+		}
+
+		log.Printf("GOAWAY: migrating %d subscriptions from session %d to %d", n, oldSessionID, newID)
+
+		h.sessionsLock.Lock()
+		delete(h.sessions, oldSessionID)
+		h.sessionsLock.Unlock()
+	}()
 }
 
 func (h *moqHandler) subscribeAndRead(s *moqtransport.Session, namespace []string, trackname string) error {

--- a/examples/date/main.go
+++ b/examples/date/main.go
@@ -13,6 +13,9 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/mengelbart/moqtransport"
 	"github.com/mengelbart/moqtransport/quicmoq"
@@ -42,6 +45,7 @@ type options struct {
 	webtransport bool
 	namespace    string
 	trackname    string
+	goawayURI    string
 }
 
 func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
@@ -61,6 +65,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.BoolVar(&opts.webtransport, "webtransport", false, "Use webtransport instead of QUIC (client only)")
 	fs.StringVar(&opts.namespace, "namespace", "clock", "Namespace to subscribe to")
 	fs.StringVar(&opts.trackname, "trackname", "second", "Track to subscribe to")
+	fs.StringVar(&opts.goawayURI, "goaway-uri", "", "URI to send in GOAWAY message (server only)")
 	err := fs.Parse(args[1:])
 	return &opts, err
 }
@@ -82,10 +87,16 @@ func run(args []string) error {
 		}
 		return err
 	}
+	var runErr error
 	if opts.server {
-		return runServer(opts)
+		runErr = runServer(opts)
+	} else {
+		runErr = runClient(opts)
 	}
-	return runClient(opts)
+	if runErr != nil && errors.Is(runErr, context.Canceled) {
+		return nil
+	}
+	return runErr
 }
 
 func runServer(opts *options) error {
@@ -100,17 +111,66 @@ func runServer(opts *options) error {
 	h := &moqHandler{
 		server:     true,
 		addr:       opts.addr,
+		goawayURI:  opts.goawayURI,
 		tlsConfig:  tlsConfig,
 		namespace:  []string{opts.namespace},
 		trackname:  opts.trackname,
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
 		publishers: make(map[moqtransport.Publisher]struct{}),
+		sessions:   make(map[uint64]*moqtransport.Session),
 	}
-	return h.runServer(context.TODO())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		log.Printf("received signal %v, sending GOAWAY to all sessions", sig)
+		h.sessionsLock.Lock()
+		for id, s := range h.sessions {
+			log.Printf("sending GOAWAY to session %d", id)
+			if err := s.GoAway(h.goawayURI); err != nil {
+				log.Printf("failed to send GOAWAY to session %d: %v", id, err)
+			}
+		}
+		h.sessionsLock.Unlock()
+		deadline := time.After(5 * time.Second)
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-deadline:
+				log.Printf("grace period expired, shutting down")
+				cancel()
+				return
+			case <-ticker.C:
+				h.lock.Lock()
+				remaining := len(h.publishers)
+				h.lock.Unlock()
+				if remaining == 0 {
+					log.Printf("all subscribers migrated, shutting down")
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	return h.runServer(ctx)
 }
 
 func runClient(opts *options) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
 	h := &moqHandler{
 		server:     false,
 		quic:       !opts.webtransport,
@@ -121,8 +181,9 @@ func runClient(opts *options) error {
 		publish:    opts.publish,
 		subscribe:  opts.subscribe,
 		publishers: make(map[moqtransport.Publisher]struct{}),
+		sessions:   make(map[uint64]*moqtransport.Session),
 	}
-	return h.runClient(context.TODO(), opts.webtransport)
+	return h.runClient(ctx, opts.webtransport)
 }
 
 func generateTLSConfigWithCertAndKey(certFile, keyFile string) (*tls.Config, error) {

--- a/remote_track.go
+++ b/remote_track.go
@@ -27,6 +27,8 @@ func (e ErrSubscribeDone) Error() string {
 // RemoteTrack is a track provided by the remote peer.
 type RemoteTrack struct {
 	requestID uint64
+	namespace []string
+	trackname string
 
 	// Expires, groupOrder, ..., parameters are returned in the SUBSCRIBE_OK.
 	// They are not updated when sending a SUBSCRIBE_UPDATE message.
@@ -53,6 +55,16 @@ type RemoteTrack struct {
 // RequestID returns the request ID of the subscription request.
 func (t *RemoteTrack) RequestID() uint64 {
 	return t.requestID
+}
+
+// Namespace returns the namespace this track is subscribed to.
+func (t *RemoteTrack) Namespace() []string {
+	return t.namespace
+}
+
+// TrackName returns the track name this track is subscribed to.
+func (t *RemoteTrack) TrackName() string {
+	return t.trackname
 }
 
 // Expires returns the duration for which the subscription is valid.
@@ -89,10 +101,12 @@ func (t *RemoteTrack) UpdateSubscription(ctx context.Context, options ...Subscri
 	return t.updateFunc(ctx, options...)
 }
 
-func newRemoteTrack(requestID uint64, unsubscribeFunc func() error, updateFunc func(context.Context, ...SubscribeUpdateOption) error) *RemoteTrack {
+func newRemoteTrack(requestID uint64, namespace []string, trackname string, unsubscribeFunc func() error, updateFunc func(context.Context, ...SubscribeUpdateOption) error) *RemoteTrack {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t := &RemoteTrack{
 		requestID:       requestID,
+		namespace:       namespace,
+		trackname:       trackname,
 		logger:          defaultLogger,
 		unsubscribeFunc: unsubscribeFunc,
 		updateFunc:      updateFunc,

--- a/remote_track.go
+++ b/remote_track.go
@@ -48,6 +48,7 @@ type RemoteTrack struct {
 
 	subGroupCount atomic.Uint64
 	fetchCount    atomic.Uint64 // should never grow larger than one for now.
+	migrating     atomic.Bool
 
 	responseChan chan error
 }
@@ -178,6 +179,9 @@ func (t *RemoteTrack) readStream(parser objectMessageParser) error {
 }
 
 func (t *RemoteTrack) done(status uint64, reason string) {
+	if t.migrating.Load() {
+		return
+	}
 	t.doneCtxCancel(&ErrSubscribeDone{
 		Status: status,
 		Reason: reason,

--- a/remote_track_map.go
+++ b/remote_track_map.go
@@ -121,3 +121,13 @@ func (m *remoteTrackMap) findByTrackAlias(alias uint64) (*RemoteTrack, bool) {
 	}
 	return m.findByRequestID(id)
 }
+
+func (m *remoteTrackMap) openTracks() []*RemoteTrack {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	tracks := make([]*RemoteTrack, 0, len(m.open))
+	for _, rt := range m.open {
+		tracks = append(tracks, rt)
+	}
+	return tracks
+}

--- a/session.go
+++ b/session.go
@@ -1061,6 +1061,22 @@ func (s *Session) onGoAway(msg *wire.GoAwayMessage) {
 	})
 }
 
+// GoAway sends a GOAWAY message to the peer with the given new session URI.
+func (s *Session) GoAway(uri string) error {
+	if !s.handshakeDone.Load() {
+		return errors.New("session handshake not completed")
+	}
+	return s.controlStream.write(&wire.GoAwayMessage{
+		NewSessionURI: uri,
+	})
+}
+
+// HandshakeDone returns a channel that is closed when the MoQ handshake
+// has completed successfully. Returns nil if Run has not been called yet.
+func (s *Session) HandshakeDone() <-chan struct{} {
+	return s.handshakeDoneCh
+}
+
 func (s *Session) onMaxRequestID(msg *wire.MaxRequestIDMessage) error {
 	return s.requestIDs.setMax(msg.RequestID)
 }

--- a/session.go
+++ b/session.go
@@ -494,7 +494,7 @@ func (s *Session) Subscribe(
 	if err != nil {
 		return nil, err
 	}
-	rt := newRemoteTrack(requestID, func() error {
+	rt := newRemoteTrack(requestID, namespace, name, func() error {
 		return s.unsubscribe(requestID)
 	}, func(ctx context.Context, options ...SubscribeUpdateOption) error {
 		return s.UpdateSubscription(ctx, requestID, options...)
@@ -668,7 +668,7 @@ func (s *Session) Fetch(
 	if err != nil {
 		return nil, err
 	}
-	rt := newRemoteTrack(requestID, func() error {
+	rt := newRemoteTrack(requestID, namespace, track, func() error {
 		return s.fetchCancel(requestID)
 	}, nil)
 	if err = s.remoteTracks.addPending(requestID, rt); err != nil {

--- a/session.go
+++ b/session.go
@@ -1077,6 +1077,70 @@ func (s *Session) HandshakeDone() <-chan struct{} {
 	return s.handshakeDoneCh
 }
 
+// Migrate transfers all established subscriptions from this session to
+// newSession. For each subscription, it re-subscribes on the new session and
+// pipes incoming data into the original RemoteTrack's buffer so that the
+// application's ReadObject loop continues seamlessly.
+//
+// The caller must establish the new connection and call Run on newSession
+// before calling Migrate. Migrate returns the number of subscriptions being
+// migrated. Per-track migration errors are logged but not returned.
+func (s *Session) Migrate(newSession *Session) (int, error) {
+	if s.ctx == nil {
+		return 0, errors.New("old session not started")
+	}
+	if newSession == nil {
+		return 0, errors.New("new session must not be nil")
+	}
+	newHandshake := newSession.HandshakeDone()
+	if newHandshake == nil {
+		return 0, errors.New("new session has not been started (Run not called)")
+	}
+	select {
+	case <-s.ctx.Done():
+		return 0, context.Cause(s.ctx)
+	case <-newHandshake:
+	}
+	tracks := s.remoteTracks.openTracks()
+	if len(tracks) == 0 {
+		return 0, nil
+	}
+	s.logger.Info("migrating subscriptions", "count", len(tracks))
+	for _, rt := range tracks {
+		go s.migrateTrack(rt, newSession)
+	}
+	return len(tracks), nil
+}
+
+func (s *Session) migrateTrack(rt *RemoteTrack, newSession *Session) {
+	s.logger.Info("migrating track", "namespace", rt.namespace, "track", rt.trackname)
+
+	// Prevent SUBSCRIBE_DONE from the old relay from cancelling the track.
+	rt.migrating.Store(true)
+
+	// Use context.Background: the old session's ctx will be cancelled when the
+	// old relay closes the connection, but the pipe must outlive it.
+	newRt, err := newSession.Subscribe(context.Background(), rt.namespace, rt.trackname)
+	if err != nil {
+		s.logger.Error("failed to migrate track", "error", err,
+			"namespace", rt.namespace, "track", rt.trackname)
+		rt.migrating.Store(false)
+		return
+	}
+	if err := s.unsubscribe(rt.requestID); err != nil {
+		s.logger.Info("unsubscribe from old relay failed", "error", err)
+	}
+	for {
+		obj, err := newRt.ReadObject(context.Background())
+		if err != nil {
+			s.logger.Info("migration pipe ended", "error", err,
+				"namespace", rt.namespace, "track", rt.trackname)
+			return
+		}
+		rt.push(obj)
+	}
+}
+
 func (s *Session) onMaxRequestID(msg *wire.MaxRequestIDMessage) error {
 	return s.requestIDs.setMax(msg.RequestID)
 }

--- a/session.go
+++ b/session.go
@@ -87,6 +87,8 @@ type Session struct {
 	localTracks  *localTrackMap
 
 	outgoingTrackStatusRequests *trackStatusRequestMap
+
+	goAwayReceived atomic.Bool
 }
 
 func (s *Session) Run(conn Connection) error {
@@ -489,6 +491,9 @@ func (s *Session) Subscribe(
 	name string,
 	options ...SubscribeOption,
 ) (*RemoteTrack, error) {
+	if s.Draining() {
+		return nil, errSessionDraining
+	}
 
 	requestID, err := s.getRequestID()
 	if err != nil {
@@ -664,6 +669,9 @@ func (s *Session) Fetch(
 	namespace []string,
 	track string,
 ) (*RemoteTrack, error) {
+	if s.Draining() {
+		return nil, errSessionDraining
+	}
 	requestID, err := s.getRequestID()
 	if err != nil {
 		return nil, err
@@ -797,6 +805,9 @@ func (s *Session) sendTrackStatus(ts TrackStatus) error {
 // peer was received or ctx is cancelled and returns an error if the
 // announcement was rejected.
 func (s *Session) Announce(ctx context.Context, namespace []string) error {
+	if s.Draining() {
+		return errSessionDraining
+	}
 	requestID, err := s.getRequestID()
 	if err != nil {
 		return err
@@ -870,6 +881,9 @@ func (s *Session) AnnounceCancel(ctx context.Context, namespace []string, errorC
 // SubscribeAnnouncements subscribes to announcements of namespaces with prefix.
 // It blocks until a response from the peer is received or ctx is cancelled.
 func (s *Session) SubscribeAnnouncements(ctx context.Context, prefix []string) error {
+	if s.Draining() {
+		return errSessionDraining
+	}
 	requestID, err := s.getRequestID()
 	if err != nil {
 		return err
@@ -937,7 +951,7 @@ func (s *Session) receive(msg wire.ControlMessage) error {
 	var err error
 	switch m := msg.(type) {
 	case *wire.GoAwayMessage:
-		s.onGoAway(m)
+		err = s.onGoAway(m)
 	case *wire.MaxRequestIDMessage:
 		err = s.onMaxRequestID(m)
 	case *wire.RequestsBlockedMessage:
@@ -1054,11 +1068,26 @@ func (s *Session) onServerSetup(m *wire.ServerSetupMessage) (err error) {
 	return nil
 }
 
-func (s *Session) onGoAway(msg *wire.GoAwayMessage) {
+func (s *Session) onGoAway(msg *wire.GoAwayMessage) error {
+	if s.goAwayReceived.Swap(true) {
+		return errMultipleGoAways
+	}
+	if len(msg.NewSessionURI) > 8192 {
+		return errGoAwayURITooLong
+	}
+	if s.conn.Perspective() == PerspectiveServer && len(msg.NewSessionURI) > 0 {
+		return errGoAwayWithURIOnServer
+	}
 	s.Handler.Handle(nil, &Message{
 		Method:        MessageGoAway,
 		NewSessionURI: msg.NewSessionURI,
 	})
+	return nil
+}
+
+// Draining returns true if a GOAWAY message has been received from the peer.
+func (s *Session) Draining() bool {
+	return s.goAwayReceived.Load()
 }
 
 // GoAway sends a GOAWAY message to the peer with the given new session URI.
@@ -1115,11 +1144,8 @@ func (s *Session) Migrate(newSession *Session) (int, error) {
 func (s *Session) migrateTrack(rt *RemoteTrack, newSession *Session) {
 	s.logger.Info("migrating track", "namespace", rt.namespace, "track", rt.trackname)
 
-	// Prevent SUBSCRIBE_DONE from the old relay from cancelling the track.
 	rt.migrating.Store(true)
 
-	// Use context.Background: the old session's ctx will be cancelled when the
-	// old relay closes the connection, but the pipe must outlive it.
 	newRt, err := newSession.Subscribe(context.Background(), rt.namespace, rt.trackname)
 	if err != nil {
 		s.logger.Error("failed to migrate track", "error", err,
@@ -1131,7 +1157,7 @@ func (s *Session) migrateTrack(rt *RemoteTrack, newSession *Session) {
 		s.logger.Info("unsubscribe from old relay failed", "error", err)
 	}
 	for {
-		obj, err := newRt.ReadObject(context.Background())
+		obj, err := newRt.ReadObject(newSession.ctx)
 		if err != nil {
 			s.logger.Info("migration pipe ended", "error", err,
 				"namespace", rt.namespace, "track", rt.trackname)

--- a/session_test.go
+++ b/session_test.go
@@ -562,7 +562,7 @@ func TestRemoteTrack_UpdateSubscription(t *testing.T) {
 			return nil
 		}
 
-		rt := newRemoteTrack(123, nil, updateFunc)
+		rt := newRemoteTrack(123, nil, "", nil, updateFunc)
 
 		err := rt.UpdateSubscription(context.Background(), WithUpdateStartLocation(Location{Group: 150, Object: 0}))
 		assert.NoError(t, err)
@@ -570,7 +570,7 @@ func TestRemoteTrack_UpdateSubscription(t *testing.T) {
 	})
 
 	t.Run("RemoteTrack UpdateSubscription returns error when updateFunc is nil", func(t *testing.T) {
-		rt := newRemoteTrack(123, nil, nil)
+		rt := newRemoteTrack(123, nil, "", nil, nil)
 
 		err := rt.UpdateSubscription(context.Background())
 		assert.Error(t, err)


### PR DESCRIPTION
Based on the session migration requirements in Draft 11, this PR implements GOAWAY handling and a mechanism for seamless subscription migration.

Main changes:
Implement GOAWAY message handling and "draining" state in the Session.
Add a Session.Migrate helper to automate transferring active subscriptions to a new session.
Enforce protocol constraints like URI length limits and blocking new requests during draining.

Some other changes:
Update the date example to demonstrate a full migration flow.
Refactor RemoteTrack to support internal data piping during migration.

Other things to improve:
Currently, the application is responsible for dialing the new connection after a GOAWAY. We should discuss if we want to add a high-level dialer/manager to the library to automate this further, or if keeping the library transport-agnostic is preferred.