### PR TITLE
Fix properties without length fields

### DIFF
--- a/internal/wire/fetch_ok_v18.go
+++ b/internal/wire/fetch_ok_v18.go
@@ -26,7 +26,6 @@ func (m *FetchOk) append_v18(buf []byte) []byte {
 			buf = append(buf, v.Bytes...)
 		}
 	}
-	buf = varint.Append(buf, uint64(len(m.Properties)))
 	for _, v := range m.Properties {
 		buf = varint.Append(buf, uint64(v.Type))
 		if v.Type%2 == 0 {
@@ -100,15 +99,8 @@ func (m *FetchOk) parse_v18(data []byte) error {
 		}
 	}
 
-	var numProperties uint64
-	numProperties, n, err = varint.Parse(data)
-	if err != nil {
-		return err
-	}
-	data = data[n:]
-
-	m.Properties = make([]KeyValuePair, numProperties)
-	for i := range numProperties {
+	m.Properties = make([]KeyValuePair, 0)
+	for len(data) > 0 {
 		typ, n, err := varint.Parse(data)
 		if err != nil {
 			return err
@@ -120,10 +112,10 @@ func (m *FetchOk) parse_v18(data []byte) error {
 			if err != nil {
 				return err
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:   typ,
 				Varint: val,
-			}
+			})
 			data = data[n:]
 		} else {
 			length, n, err := varint.Parse(data)
@@ -134,10 +126,10 @@ func (m *FetchOk) parse_v18(data []byte) error {
 			if len(data) < int(length) {
 				return io.ErrUnexpectedEOF
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:  typ,
 				Bytes: data[:length],
-			}
+			})
 			data = data[length:]
 		}
 	}

--- a/internal/wire/publish_ok_v18.go
+++ b/internal/wire/publish_ok_v18.go
@@ -19,7 +19,6 @@ func (m *PublishOk) append_v18(buf []byte) []byte {
 			buf = append(buf, v.Bytes...)
 		}
 	}
-	buf = varint.Append(buf, uint64(len(m.Properties)))
 	for _, v := range m.Properties {
 		buf = varint.Append(buf, uint64(v.Type))
 		if v.Type%2 == 0 {
@@ -78,15 +77,8 @@ func (m *PublishOk) parse_v18(data []byte) error {
 		}
 	}
 
-	var numProperties uint64
-	numProperties, n, err = varint.Parse(data)
-	if err != nil {
-		return err
-	}
-	data = data[n:]
-
-	m.Properties = make([]KeyValuePair, numProperties)
-	for i := range numProperties {
+	m.Properties = make([]KeyValuePair, 0)
+	for len(data) > 0 {
 		typ, n, err := varint.Parse(data)
 		if err != nil {
 			return err
@@ -98,10 +90,10 @@ func (m *PublishOk) parse_v18(data []byte) error {
 			if err != nil {
 				return err
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:   typ,
 				Varint: val,
-			}
+			})
 			data = data[n:]
 		} else {
 			length, n, err := varint.Parse(data)
@@ -112,10 +104,10 @@ func (m *PublishOk) parse_v18(data []byte) error {
 			if len(data) < int(length) {
 				return io.ErrUnexpectedEOF
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:  typ,
 				Bytes: data[:length],
-			}
+			})
 			data = data[length:]
 		}
 	}

--- a/internal/wire/publish_v18.go
+++ b/internal/wire/publish_v18.go
@@ -28,7 +28,6 @@ func (m *Publish) append_v18(buf []byte) []byte {
 			buf = append(buf, v.Bytes...)
 		}
 	}
-	buf = varint.Append(buf, uint64(len(m.Properties)))
 	for _, v := range m.Properties {
 		buf = varint.Append(buf, uint64(v.Type))
 		if v.Type%2 == 0 {
@@ -135,15 +134,8 @@ func (m *Publish) parse_v18(data []byte) error {
 		}
 	}
 
-	var numProperties uint64
-	numProperties, n, err = varint.Parse(data)
-	if err != nil {
-		return err
-	}
-	data = data[n:]
-
-	m.Properties = make([]KeyValuePair, numProperties)
-	for i := range numProperties {
+	m.Properties = make([]KeyValuePair, 0)
+	for len(data) > 0 {
 		typ, n, err := varint.Parse(data)
 		if err != nil {
 			return err
@@ -155,10 +147,10 @@ func (m *Publish) parse_v18(data []byte) error {
 			if err != nil {
 				return err
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:   typ,
 				Varint: val,
-			}
+			})
 			data = data[n:]
 		} else {
 			length, n, err := varint.Parse(data)
@@ -169,10 +161,10 @@ func (m *Publish) parse_v18(data []byte) error {
 			if len(data) < int(length) {
 				return io.ErrUnexpectedEOF
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:  typ,
 				Bytes: data[:length],
-			}
+			})
 			data = data[length:]
 		}
 	}

--- a/internal/wire/request_ok_v18.go
+++ b/internal/wire/request_ok_v18.go
@@ -19,7 +19,6 @@ func (m *RequestOk) append_v18(buf []byte) []byte {
 			buf = append(buf, v.Bytes...)
 		}
 	}
-	buf = varint.Append(buf, uint64(len(m.Properties)))
 	for _, v := range m.Properties {
 		buf = varint.Append(buf, uint64(v.Type))
 		if v.Type%2 == 0 {
@@ -78,15 +77,8 @@ func (m *RequestOk) parse_v18(data []byte) error {
 		}
 	}
 
-	var numProperties uint64
-	numProperties, n, err = varint.Parse(data)
-	if err != nil {
-		return err
-	}
-	data = data[n:]
-
-	m.Properties = make([]KeyValuePair, numProperties)
-	for i := range numProperties {
+	m.Properties = make([]KeyValuePair, 0)
+	for len(data) > 0 {
 		typ, n, err := varint.Parse(data)
 		if err != nil {
 			return err
@@ -98,10 +90,10 @@ func (m *RequestOk) parse_v18(data []byte) error {
 			if err != nil {
 				return err
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:   typ,
 				Varint: val,
-			}
+			})
 			data = data[n:]
 		} else {
 			length, n, err := varint.Parse(data)
@@ -112,10 +104,10 @@ func (m *RequestOk) parse_v18(data []byte) error {
 			if len(data) < int(length) {
 				return io.ErrUnexpectedEOF
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:  typ,
 				Bytes: data[:length],
-			}
+			})
 			data = data[length:]
 		}
 	}

--- a/internal/wire/subscribe_ok_v18.go
+++ b/internal/wire/subscribe_ok_v18.go
@@ -20,7 +20,6 @@ func (m *SubscribeOk) append_v18(buf []byte) []byte {
 			buf = append(buf, v.Bytes...)
 		}
 	}
-	buf = varint.Append(buf, uint64(len(m.Properties)))
 	for _, v := range m.Properties {
 		buf = varint.Append(buf, uint64(v.Type))
 		if v.Type%2 == 0 {
@@ -85,15 +84,8 @@ func (m *SubscribeOk) parse_v18(data []byte) error {
 		}
 	}
 
-	var numProperties uint64
-	numProperties, n, err = varint.Parse(data)
-	if err != nil {
-		return err
-	}
-	data = data[n:]
-
-	m.Properties = make([]KeyValuePair, numProperties)
-	for i := range numProperties {
+	m.Properties = make([]KeyValuePair, 0)
+	for len(data) > 0 {
 		typ, n, err := varint.Parse(data)
 		if err != nil {
 			return err
@@ -105,10 +97,10 @@ func (m *SubscribeOk) parse_v18(data []byte) error {
 			if err != nil {
 				return err
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:   typ,
 				Varint: val,
-			}
+			})
 			data = data[n:]
 		} else {
 			length, n, err := varint.Parse(data)
@@ -119,10 +111,10 @@ func (m *SubscribeOk) parse_v18(data []byte) error {
 			if len(data) < int(length) {
 				return io.ErrUnexpectedEOF
 			}
-			m.Properties[i] = KeyValuePair{
+			m.Properties = append(m.Properties, KeyValuePair{
 				Type:  typ,
 				Bytes: data[:length],
-			}
+			})
 			data = data[length:]
 		}
 	}

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -41,7 +41,7 @@ func (m *Subscribe) Type() ControlMessageType {
 type SubscribeOk struct {
 	TrackAlias uint64         `proto:"varint"`
 	Parameters []KeyValuePair `proto:"moq_kvp_list"`
-	Properties []KeyValuePair `proto:"moq_kvp_list"` // TODO: kvp list without length?
+	Properties []KeyValuePair `proto:"moq_kvp_list_no_length"`
 }
 
 func (m *SubscribeOk) Type() ControlMessageType {
@@ -54,7 +54,7 @@ type Publish struct {
 	TrackName      []byte         `proto:"tlv_bytes"`
 	TrackAlias     uint64         `proto:"varint"`
 	Parameters     []KeyValuePair `proto:"moq_kvp_list"`
-	Properties     []KeyValuePair `proto:"moq_kvp_list"` // TODO: kvp list without length?
+	Properties     []KeyValuePair `proto:"moq_kvp_list_no_length"`
 }
 
 func (m *Publish) Type() ControlMessageType {
@@ -63,7 +63,7 @@ func (m *Publish) Type() ControlMessageType {
 
 type PublishOk struct {
 	Parameters []KeyValuePair `proto:"moq_kvp_list"`
-	Properties []KeyValuePair `proto:"moq_kvp_list"` // TODO: kvp list without length?
+	Properties []KeyValuePair `proto:"moq_kvp_list_no_length"`
 }
 
 func (m *PublishOk) Type() ControlMessageType {
@@ -95,7 +95,7 @@ type FetchOk struct {
 	EndOfTrack  bool           `proto:"bool"`
 	EndLocation Location       `proto:"moq_location"`
 	Parameters  []KeyValuePair `proto:"moq_kvp_list"`
-	Properties  []KeyValuePair `proto:"moq_kvp_list"` // TODO: kvp list without length?
+	Properties  []KeyValuePair `proto:"moq_kvp_list_no_length"`
 }
 
 func (m *FetchOk) Type() ControlMessageType {
@@ -179,7 +179,7 @@ func (m *RequestUpdate) Type() ControlMessageType {
 
 type RequestOk struct {
 	Parameters []KeyValuePair `proto:"moq_kvp_list"`
-	Properties []KeyValuePair `proto:"moq_kvp_list"`
+	Properties []KeyValuePair `proto:"moq_kvp_list_no_length"`
 }
 
 func (m *RequestOk) Type() ControlMessageType {
@@ -190,6 +190,7 @@ type RequestError struct {
 	ErrorCode     uint64 `proto:"varint"`
 	RetryInterval uint64 `proto:"varint"`
 	ErrorReason   string `proto:"tlv_string"`
+	// TODO: Implement Redirect
 }
 
 func (m *RequestError) Type() ControlMessageType {

--- a/wiregen/generator.go
+++ b/wiregen/generator.go
@@ -61,6 +61,17 @@ var appenderTemplates = map[string]*template.Template{
 	}
 `)),
 
+	"moq_kvp_list_no_length": template.Must(template.New("moq_kvp_list_no_length_append").Parse(`	for _, v:= range m.{{ .Field }} {
+		buf = varint.Append(buf, uint64(v.Type))
+		if v.Type % 2 == 0 {
+			buf = varint.Append(buf, uint64(v.Varint))
+		} else {
+			buf = varint.Append(buf, uint64(len(v.Bytes)))
+			buf = append(buf, v.Bytes...)
+		}
+	}
+`)),
+
 	"bool": template.Must(template.New("bool_append").Parse(`	if m.{{ .Field }} {
 		buf = append(buf, byte(1))
 	} else {
@@ -187,6 +198,42 @@ var parserTemplates = map[string]*template.Template{
 				Type: typ,
 				Bytes: data[:length],
 			}
+			data = data[length:]
+		}
+	}
+`)),
+
+	"moq_kvp_list_no_length": template.Must(template.New("moq_kvp_list_no_length_parse").Parse(`	m.{{ .Field }} = make([]KeyValuePair, 0)
+	for len(data) > 0 {
+		typ, n, err := varint.Parse(data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+
+		if typ % 2 == 0 {
+			val, n, err := varint.Parse(data)
+			if err != nil {
+				return err
+			}
+			m.{{ .Field }} = append(m.{{ .Field }}, KeyValuePair{
+				Type: typ,
+				Varint: val,
+			})
+			data = data[n:]
+		} else {
+			length, n, err := varint.Parse(data)
+			if err != nil {
+				return err
+			}
+			data = data[n:]
+			if len(data) < int(length) {
+				return io.ErrUnexpectedEOF
+			}
+			m.{{ .Field }} = append(m.{{ .Field }}, KeyValuePair{
+				Type: typ,
+				Bytes: data[:length],
+			})
 			data = data[length:]
 		}
 	}


### PR DESCRIPTION
Some messages have KVP list fields (properties) that don't use a length and instead just extend until the end of the message.