### PR TITLE
Rename `ErrorCodeSubscribe*` error types to `SubscribeErrorCode*`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -25,32 +25,32 @@ const (
 	ErrorCodeExpiredAuthToken         ErrorCode = 0x18
 )
 
-// ErrorCodeSubscribe is a Subscribe error code
-type ErrorCodeSubscribe uint64
+// SubscribeErrorCode is a Subscribe error code
+type SubscribeErrorCode uint64
 
 const (
-	ErrorCodeSubscribeInternal           ErrorCodeSubscribe = 0x00
-	ErrorCodeSubscribeUnauthorized       ErrorCodeSubscribe = 0x01
-	ErrorCodeSubscribeTimeout            ErrorCodeSubscribe = 0x02
-	ErrorCodeSubscribeNotSupported       ErrorCodeSubscribe = 0x03
-	ErrorCodeSubscribeTrackDoesNotExist  ErrorCodeSubscribe = 0x04
-	ErrorCodeSubscribeInvalidRange       ErrorCodeSubscribe = 0x05
-	ErrorCodeSubscribeMalformedAuthToken ErrorCodeSubscribe = 0x10
-	ErrorCodeSubscribeExpiredAuthToken   ErrorCodeSubscribe = 0x12
+	SubscribeErrorCodeInternal           SubscribeErrorCode = 0x00
+	SubscribeErrorCodeUnauthorized       SubscribeErrorCode = 0x01
+	SubscribeErrorCodeTimeout            SubscribeErrorCode = 0x02
+	SubscribeErrorCodeNotSupported       SubscribeErrorCode = 0x03
+	SubscribeErrorCodeTrackDoesNotExist  SubscribeErrorCode = 0x04
+	SubscribeErrorCodeInvalidRange       SubscribeErrorCode = 0x05
+	SubscribeErrorCodeMalformedAuthToken SubscribeErrorCode = 0x10
+	SubscribeErrorCodeExpiredAuthToken   SubscribeErrorCode = 0x12
 )
 
-// ErrorCodeSubscribeDone is a subscribe done error code
-type ErrorCodeSubscribeDone uint64
+// SubscribeErrorCodeDone is a subscribe done error code
+type SubscribeErrorCodeDone uint64
 
 const (
-	ErrorCodeSubscribeDoneInternal          ErrorCodeSubscribeDone = 0x00
-	ErrorCodeSubscribeDoneUnauthorized      ErrorCodeSubscribeDone = 0x01
-	ErrorCodeSubscribeDoneTrackEnded        ErrorCodeSubscribeDone = 0x02
-	ErrorCodeSubscribeDoneSubscriptionEnded ErrorCodeSubscribeDone = 0x03
-	ErrorCodeSubscribeDoneGoingAway         ErrorCodeSubscribeDone = 0x04
-	ErrorCodeSubscribeDoneExpired           ErrorCodeSubscribeDone = 0x05
-	ErrorCodeSubscribeDoneTooFarBehind      ErrorCodeSubscribeDone = 0x06
-	ErrorCodeSubscribeDoneMalformedTrack    ErrorCodeSubscribeDone = 0x07
+	SubscribeErrorCodeDoneInternal          SubscribeErrorCodeDone = 0x00
+	SubscribeErrorCodeDoneUnauthorized      SubscribeErrorCodeDone = 0x01
+	SubscribeErrorCodeDoneTrackEnded        SubscribeErrorCodeDone = 0x02
+	SubscribeErrorCodeDoneSubscriptionEnded SubscribeErrorCodeDone = 0x03
+	SubscribeErrorCodeDoneGoingAway         SubscribeErrorCodeDone = 0x04
+	SubscribeErrorCodeDoneExpired           SubscribeErrorCodeDone = 0x05
+	SubscribeErrorCodeDoneTooFarBehind      SubscribeErrorCodeDone = 0x06
+	SubscribeErrorCodeDoneMalformedTrack    SubscribeErrorCodeDone = 0x07
 )
 
 // ErrorCodePublish is a publish error code
@@ -95,16 +95,16 @@ const (
 	ErrorCodeAnnouncementExpiredAuthToken ErrorCodeAnnounce = 0x12
 )
 
-// ErrorCodeSubscribeNamespace is a subscribe namespaces error code
-type ErrorCodeSubscribeNamespace uint64
+// SubscribeErrorCodeNamespace is a subscribe namespaces error code
+type SubscribeErrorCodeNamespace uint64
 
 const (
-	ErrorCodeSubscribeNamespaceInternal               ErrorCodeSubscribeNamespace = 0x00
-	ErrorCodeSubscribeNamespaceUnauthorized           ErrorCodeSubscribeNamespace = 0x01
-	ErrorCodeSubscribeNamespaceTimeout                ErrorCodeSubscribeNamespace = 0x02
-	ErrorCodeSubscribeNamespaceNotSupported           ErrorCodeSubscribeNamespace = 0x03
-	ErrorCodeSubscribeNamespaceNamespacePrefixUnknown ErrorCodeSubscribeNamespace = 0x04
-	ErrorCodeSubscribeNamespaceNamespacePrefixOverlap ErrorCodeSubscribeNamespace = 0x05
-	ErrorCodeSubscribeNamespaceMalformedAuthToken     ErrorCodeSubscribeNamespace = 0x10
-	ErrorCodeSubscribeNamespaceExpiredAuthToken       ErrorCodeSubscribeNamespace = 0x12
+	SubscribeErrorCodeNamespaceInternal               SubscribeErrorCodeNamespace = 0x00
+	SubscribeErrorCodeNamespaceUnauthorized           SubscribeErrorCodeNamespace = 0x01
+	SubscribeErrorCodeNamespaceTimeout                SubscribeErrorCodeNamespace = 0x02
+	SubscribeErrorCodeNamespaceNotSupported           SubscribeErrorCodeNamespace = 0x03
+	SubscribeErrorCodeNamespaceNamespacePrefixUnknown SubscribeErrorCodeNamespace = 0x04
+	SubscribeErrorCodeNamespaceNamespacePrefixOverlap SubscribeErrorCodeNamespace = 0x05
+	SubscribeErrorCodeNamespaceMalformedAuthToken     SubscribeErrorCodeNamespace = 0x10
+	SubscribeErrorCodeNamespaceExpiredAuthToken       SubscribeErrorCodeNamespace = 0x12
 )

--- a/examples/date/endpoint.go
+++ b/examples/date/endpoint.go
@@ -145,7 +145,7 @@ func (e *endpoint) setupDateTrack() {
 			if err != nil {
 				log.Printf("failed to open new subgroup: %v", err)
 				// TODO: Close publisher with error
-				// p.CloseWithError(uint64(moqtransport.ErrorCodeSubscribeDoneSubscriptionEnded), "") //nolint:errcheck
+				// p.CloseWithError(uint64(moqtransport.SubscribeErrorCodeDoneSubscriptionEnded), "") //nolint:errcheck
 				delete(e.publishers, p)
 				continue
 			}

--- a/examples/date/handler.go
+++ b/examples/date/handler.go
@@ -21,12 +21,12 @@ func (h *handler) HandleSubscribe(r *moqtransport.IncomingSubscribeRequest) {
 	ns := tupleToStringList(r.Namespace())
 	if !h.endpoint.publish {
 		log.Printf("sessionNr: %d got unexpected subscribe request: %v", h.sessionID, ns)
-		r.Reject(moqtransport.ErrorCodeSubscribeTrackDoesNotExist, "endpoint does not publish any tracks") //nolint:errcheck
+		r.Reject(moqtransport.SubscribeErrorCodeTrackDoesNotExist, "endpoint does not publish any tracks") //nolint:errcheck
 		return
 	}
 	if !tupleEqual(ns, h.endpoint.namespace) || string(r.Name()) != h.endpoint.trackname {
 		log.Printf("got unexpected subscribe namespace/track: %v/%v, expected %v/%v", ns, r.Name(), h.endpoint.namespace, h.endpoint.trackname)
-		r.Reject(moqtransport.ErrorCodeSubscribeTrackDoesNotExist, "unknown track")
+		r.Reject(moqtransport.SubscribeErrorCodeTrackDoesNotExist, "unknown track")
 		return
 	}
 	// TODO: Set track alias

--- a/incoming_subscribe_request.go
+++ b/incoming_subscribe_request.go
@@ -64,7 +64,7 @@ func (r *IncomingSubscribeRequest) Accept(trackAlias uint64) {
 	}
 }
 
-func (r *IncomingSubscribeRequest) Reject(code ErrorCodeSubscribe, reason string) {
+func (r *IncomingSubscribeRequest) Reject(code SubscribeErrorCode, reason string) {
 	err := r.streamWriter.Write(&wire.RequestError{
 		ErrorCode:     uint64(code),
 		RetryInterval: 0, // TODO: Add retry interval if needed


### PR DESCRIPTION
Fixes #242.